### PR TITLE
Missing icon

### DIFF
--- a/bar.go
+++ b/bar.go
@@ -48,6 +48,9 @@ func taskbarIconTapped(win Window) {
 }
 
 func (b *bar) WindowAdded(win Window) {
+	if win.SkipTaskbar() {
+		return
+	}
 	data := b.desk.IconProvider().FindAppFromWinInfo(win)
 	if data == nil {
 		return
@@ -62,6 +65,9 @@ func (b *bar) WindowAdded(win Window) {
 }
 
 func (b *bar) WindowRemoved(win Window) {
+	if win.SkipTaskbar() {
+		return
+	}
 	for i, icon := range icons {
 		if icon.taskbarWindow == nil || win != icon.taskbarWindow {
 			continue

--- a/barwidget_test.go
+++ b/barwidget_test.go
@@ -44,6 +44,10 @@ func (*dummyWindow) TopWindow() bool {
 	return true
 }
 
+func (*dummyWindow) SkipTaskbar() bool {
+	return false
+}
+
 func (*dummyWindow) Focus() {
 	// no-op
 }

--- a/internal/fdo.go
+++ b/internal/fdo.go
@@ -119,7 +119,7 @@ func fdoLookupApplicationByMetadata(appName string) desktop.AppData {
 }
 
 //fdoLookupApplication looks up an application by name and returns an fdoApplicationData struct
-func fdoLookupApplication(appName string, fallbackIfMissing bool) desktop.AppData {
+func fdoLookupApplication(appName string) desktop.AppData {
 	locationLookup := fdoLookupXdgDataDirs()
 	for _, dataDir := range locationLookup {
 		testLocation := filepath.Join(dataDir, "applications", appName+".desktop")
@@ -128,14 +128,7 @@ func fdoLookupApplication(appName string, fallbackIfMissing bool) desktop.AppDat
 		}
 	}
 	//If no match was found checking by filenames, check by file contents
-	app := fdoLookupApplicationByMetadata(appName)
-	if app != nil {
-		return app
-	}
-	if fallbackIfMissing {
-		return &fdoApplicationData{name: appName}
-	}
-	return nil
+	return fdoLookupApplicationByMetadata(appName)
 }
 
 //fdoLookupApplicationPartial looks up an application by a partial name and returns all matches in an fdoApplicationData struct slice
@@ -158,21 +151,25 @@ func fdoLookupApplicationsMatching(appName string) []desktop.AppData {
 
 //fdoLookupApplicationWinInfo looks up an application based on window info and returns an fdoApplicationData struct
 func fdoLookupApplicationWinInfo(win desktop.Window) desktop.AppData {
-	icon := fdoLookupApplication(win.Title(), false)
+	icon := fdoLookupApplication(win.Title())
 	if icon != nil {
 		return icon
 	}
 	for _, class := range win.Class() {
-		icon := fdoLookupApplication(class, false)
+		icon := fdoLookupApplication(class)
 		if icon != nil {
 			return icon
 		}
 	}
-	icon = fdoLookupApplication(win.Command(), false)
+	icon = fdoLookupApplication(win.Command())
 	if icon != nil {
 		return icon
 	}
-	return fdoLookupApplication(win.IconName(), true)
+	icon = fdoLookupApplication(win.IconName())
+	if icon != nil {
+		return icon
+	}
+	return &fdoApplicationData{name: win.Title()}
 }
 
 // lookupAnyIconSizeInThemeDir walks file inside of a directory in reverse order to make sure larger sized icons are found first
@@ -373,7 +370,7 @@ type fdoIconProvider struct {
 
 //FindAppFromName matches an icon name to a location and returns an AppData interface
 func (f *fdoIconProvider) FindAppFromName(appName string) desktop.AppData {
-	return fdoLookupApplication(appName, false)
+	return fdoLookupApplication(appName)
 }
 
 //FindIconFromPartialAppName returns a list of icons that match a partial name of an app and returns an AppData slice

--- a/internal/fdo_test.go
+++ b/internal/fdo_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"fyne.io/desktop"
+	wmTheme "fyne.io/desktop/theme"
 	"fyne.io/fyne"
 	_ "fyne.io/fyne/test"
 )
@@ -107,14 +108,14 @@ func setTestEnv(t *testing.T) {
 //applications/app1.desktop and icons/default_theme/apps/32x32/app1.png
 func TestFdoLookupDefaultTheme(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app1")
+	data := fdoLookupApplication("app1", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/com.fyne.app.desktop and icons/default_theme/apps/scalable/app2.svg
 func TestFdoFileNameMisMatchAndScalable(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app2")
+	data := fdoLookupApplication("app2", false)
 	assert.Equal(t, true, exists(data))
 }
 
@@ -128,49 +129,60 @@ func TestFdoIconNameIsPath(t *testing.T) {
 		fyne.LogError("Could not create desktop for Icon Name path example", err)
 		t.FailNow()
 	}
-	data := fdoLookupApplication("app3")
+	data := fdoLookupApplication("app3", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app4.desktop and pixmaps/app4.png
 func TestFdoIconInPixmaps(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app4")
+	data := fdoLookupApplication("app4", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app5.desktop and icons/hicolor/32x32/apps/app5.png
 func TestFdoIconHicolorFallback(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app5")
+	data := fdoLookupApplication("app5", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app6.desktop and icons/hicolor/scalable/apps/app6.svg
 func TestFdoIconHicolorFallbackScalable(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app6")
+	data := fdoLookupApplication("app6", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app7.desktop and icons/default_theme/apps/16x16/app7.png
 func TestFdoLookupDefaultThemeDifferentSize(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app7")
+	data := fdoLookupApplication("app7", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app8.desktop and icons/third_theme/apps/32/app8.png
 func TestFdoLookupAnyThemeFallback(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app8")
+	data := fdoLookupApplication("app8", false)
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/xterm.desktop and icons/third_theme/emblems/16x16/app9.png
 func TestFdoLookupIconNotInApps(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("xterm")
+	data := fdoLookupApplication("xterm", false)
+	assert.Equal(t, true, exists(data))
+}
+
+//missing - not able to match
+func TestFdoLookupMissing(t *testing.T) {
+	setTestEnv(t)
+	data := fdoLookupApplication("NoMatch", true)
+	if exists(data) {
+		assert.Equal(t, "NoMatch", data.Name())
+		assert.Equal(t, wmTheme.BrokenImageIcon, data.Icon(iconTheme, iconSize))
+	}
 	assert.Equal(t, true, exists(data))
 }
 

--- a/internal/fdo_test.go
+++ b/internal/fdo_test.go
@@ -112,14 +112,14 @@ func setTestEnv(t *testing.T) {
 //applications/app1.desktop and icons/default_theme/apps/32x32/app1.png
 func TestFdoLookupDefaultTheme(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app1", false)
+	data := fdoLookupApplication("app1")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/com.fyne.app.desktop and icons/default_theme/apps/scalable/app2.svg
 func TestFdoFileNameMisMatchAndScalable(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app2", false)
+	data := fdoLookupApplication("app2")
 	assert.Equal(t, true, exists(data))
 }
 
@@ -133,56 +133,57 @@ func TestFdoIconNameIsPath(t *testing.T) {
 		fyne.LogError("Could not create desktop for Icon Name path example", err)
 		t.FailNow()
 	}
-	data := fdoLookupApplication("app3", false)
+	data := fdoLookupApplication("app3")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app4.desktop and pixmaps/app4.png
 func TestFdoIconInPixmaps(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app4", false)
+	data := fdoLookupApplication("app4")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app5.desktop and icons/hicolor/32x32/apps/app5.png
 func TestFdoIconHicolorFallback(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app5", false)
+	data := fdoLookupApplication("app5")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app6.desktop and icons/hicolor/scalable/apps/app6.svg
 func TestFdoIconHicolorFallbackScalable(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app6", false)
+	data := fdoLookupApplication("app6")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app7.desktop and icons/default_theme/apps/16x16/app7.png
 func TestFdoLookupDefaultThemeDifferentSize(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app7", false)
+	data := fdoLookupApplication("app7")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/app8.desktop and icons/third_theme/apps/32/app8.png
 func TestFdoLookupAnyThemeFallback(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("app8", false)
+	data := fdoLookupApplication("app8")
 	assert.Equal(t, true, exists(data))
 }
 
 //applications/xterm.desktop and icons/third_theme/emblems/16x16/app9.png
 func TestFdoLookupIconNotInApps(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("xterm", false)
+	data := fdoLookupApplication("xterm")
 	assert.Equal(t, true, exists(data))
 }
 
 //missing - not able to match
 func TestFdoLookupMissing(t *testing.T) {
 	setTestEnv(t)
-	data := fdoLookupApplication("NoMatch", true)
+	win1 := &dummyWindow{title: "NoMatch"}
+	data := fdoLookupApplicationWinInfo(win1)
 	if exists(data) {
 		assert.Equal(t, "NoMatch", data.Name())
 		assert.Equal(t, wmTheme.BrokenImageIcon, data.Icon(iconTheme, iconSize))

--- a/internal/fdo_test.go
+++ b/internal/fdo_test.go
@@ -56,6 +56,10 @@ func (*dummyWindow) TopWindow() bool {
 	return true
 }
 
+func (*dummyWindow) SkipTaskbar() bool {
+	return false
+}
+
 func (*dummyWindow) Focus() {
 	// no-op
 }

--- a/internal/testdata/applications/app3.desktop
+++ b/internal/testdata/applications/app3.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Name=App3
 Exec=app3
-Icon=app3
+Icon=/home/stephen/go/src/fyne.io/desktop/internal/testdata/icons/app3.png

--- a/internal/testdata/applications/app3.desktop
+++ b/internal/testdata/applications/app3.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Name=App3
 Exec=app3
-Icon=/home/stephen/go/src/fyne.io/desktop/internal/testdata/icons/app3.png
+Icon=app3

--- a/wm.go
+++ b/wm.go
@@ -14,14 +14,15 @@ type WindowManager interface {
 // Window represents a single managed window within a window manager.
 // There may be borders or not depending on configuration.
 type Window interface {
-	Decorated() bool  // Should this window have borders drawn?
-	Title() string    // The name of this window
-	Class() []string  // The class of this window
-	Command() string  // The command of this window
-	IconName() string // The icon name of this window
-	Iconic() bool     // Is the window Iconified?
-	Maximized() bool  // Is the window Maximized?
-	TopWindow() bool  // Is the the window on top?
+	Decorated() bool   // Should this window have borders drawn?
+	Title() string     // The name of this window
+	Class() []string   // The class of this window
+	Command() string   // The command of this window
+	IconName() string  // The icon name of this window
+	Iconic() bool      // Is the window Iconified?
+	Maximized() bool   // Is the window Maximized?
+	TopWindow() bool   // Is this the window on top?
+	SkipTaskbar() bool // Should this window be added to the taskbar?
 
 	Focus()            // Ask this window to get input focus
 	Close()            // Close this window and possibly the application running it

--- a/wm/client.go
+++ b/wm/client.go
@@ -26,7 +26,6 @@ type client struct {
 
 	iconic    bool
 	maximized bool
-	root      bool
 
 	restoreX, restoreY          int16
 	restoreWidth, restoreHeight uint16

--- a/wm/client.go
+++ b/wm/client.go
@@ -26,6 +26,7 @@ type client struct {
 
 	iconic    bool
 	maximized bool
+	root      bool
 
 	restoreX, restoreY          int16
 	restoreWidth, restoreHeight uint16
@@ -78,6 +79,19 @@ func (c *client) Maximized() bool {
 func (c *client) TopWindow() bool {
 	if c.wm.TopWindow() == c {
 		return true
+	}
+	return false
+}
+
+func (c *client) SkipTaskbar() bool {
+	extendedHints := windowExtendedHintsGet(c.wm.x, c.win)
+	if extendedHints == nil {
+		return false
+	}
+	for _, hint := range extendedHints {
+		if hint == "_NET_WM_STATE_SKIP_TASKBAR" {
+			return true
+		}
 	}
 	return false
 }

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -331,6 +331,10 @@ func (x *x11WM) hideWindow(win xproto.Window) {
 }
 
 func (x *x11WM) setupWindow(win xproto.Window) {
+	if windowName(x.x, win) == "" {
+		windowExtendedHintsAdd(x.x, win, "_NET_WM_STATE_SKIP_TASKBAR")
+		windowExtendedHintsAdd(x.x, win, "_NET_WM_STATE_SKIP_PAGER")
+	}
 	c := x.clientForWin(win)
 	if c != nil {
 		c.(*client).newFrame()
@@ -381,8 +385,6 @@ func (x *x11WM) frameExisting() {
 		if attrs.MapState == xproto.MapStateUnmapped {
 			continue
 		}
-		windowExtendedHintsAdd(x.x, child, "_NET_WM_STATE_SKIP_TASKBAR")
-		windowExtendedHintsAdd(x.x, child, "_NET_WM_STATE_SKIP_PAGER")
 		x.setupWindow(child)
 	}
 }

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -342,6 +342,7 @@ func (x *x11WM) setupWindow(win xproto.Window) {
 	if x.root != nil && windowName(x.x, win) == x.root.Title() {
 		return
 	}
+
 	x.AddWindow(c)
 	x.RaiseToTop(c)
 }
@@ -380,7 +381,8 @@ func (x *x11WM) frameExisting() {
 		if attrs.MapState == xproto.MapStateUnmapped {
 			continue
 		}
-
+		windowExtendedHintsAdd(x.x, child, "_NET_WM_STATE_SKIP_TASKBAR")
+		windowExtendedHintsAdd(x.x, child, "_NET_WM_STATE_SKIP_PAGER")
 		x.setupWindow(child)
 	}
 }

--- a/wm/property.go
+++ b/wm/property.go
@@ -17,7 +17,7 @@ func windowName(x *xgbutil.XUtil, win xproto.Window) string {
 	if err != nil {
 		name, err = ewmh.WmNameGet(x, win)
 		if err != nil {
-			return "Noname"
+			return ""
 		}
 	}
 

--- a/wm/property.go
+++ b/wm/property.go
@@ -97,6 +97,15 @@ func windowStateGet(x *xgbutil.XUtil, win xproto.Window) uint {
 	return state.State
 }
 
+func windowExtendedHintsGet(x *xgbutil.XUtil, win xproto.Window) []string {
+	extendedHints, err := ewmh.WmStateGet(x, win)
+	if err != nil {
+		fyne.LogError("Could not get extended hints", err)
+		return nil
+	}
+	return extendedHints
+}
+
 func windowExtendedHintsAdd(x *xgbutil.XUtil, win xproto.Window, hint string) {
 	extendedHints, err := ewmh.WmStateGet(x, win)
 	if err != nil {

--- a/wm/stack_test.go
+++ b/wm/stack_test.go
@@ -43,6 +43,10 @@ func (*dummyWindow) TopWindow() bool {
 	return true
 }
 
+func (*dummyWindow) SkipTaskbar() bool {
+	return false
+}
+
 func (*dummyWindow) Focus() {
 	// no-op
 }


### PR DESCRIPTION
This adds a missing icon when a .desktop match can not be found so that windows without matches still appear on the taskbar.  It also introduces hint handling for _NET_WM_SKIP_TASKBAR and sets this hint  on the root window children so that they skip the taskbar.