### PR TITLE
Add the ability to move and resize windows not using Fyne borders.

### DIFF
--- a/wm/client.go
+++ b/wm/client.go
@@ -252,6 +252,12 @@ func (c *client) uniconifyClient() {
 }
 
 func (c *client) maximizeClient() {
+	//This is hack to make unmaximizing with Chromium work since Chromium
+	//only sends the add signal for both maximize/unmaximize
+	if c.maximized {
+		c.unmaximizeClient()
+		return
+	}
 	c.maximized = true
 	c.frame.maximizeApply()
 }
@@ -259,6 +265,14 @@ func (c *client) maximizeClient() {
 func (c *client) unmaximizeClient() {
 	c.maximized = false
 	c.frame.unmaximizeApply()
+}
+
+func (c *client) setWindowGeometry(x int16, y int16, width uint16, height uint16) {
+	c.frame.updateGeometry(x, y, width, height)
+}
+
+func (c *client) getWindowGeometry() (int16, int16, uint16, uint16) {
+	return c.frame.getGeometry()
 }
 
 func (c *client) newFrame() {

--- a/wm/client.go
+++ b/wm/client.go
@@ -157,7 +157,7 @@ func (c *client) Unfullscreen() {
 }
 
 func (c *client) sendStateMessage(state int) {
-	stateChangeAtom, err := xprop.Atm(c.wm.x, "WM_STATE_CHANGE")
+	stateChangeAtom, err := xprop.Atm(c.wm.x, "WM_CHANGE_STATE")
 	if err != nil {
 		fyne.LogError("Error getting X Atom", err)
 		return

--- a/wm/client.go
+++ b/wm/client.go
@@ -174,13 +174,11 @@ func (c *client) sendStateMessage(state int) {
 func (c *client) Iconify() {
 	c.sendStateMessage(icccm.StateIconic)
 	windowStateSet(c.wm.x, c.win, icccm.StateIconic)
-	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_HIDDEN")
 }
 
 func (c *client) Uniconify() {
 	c.sendStateMessage(icccm.StateNormal)
 	windowStateSet(c.wm.x, c.win, icccm.StateNormal)
-	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_HIDDEN")
 }
 
 func (c *client) maximizeMessage(action clientMessageStateAction) {
@@ -190,14 +188,10 @@ func (c *client) maximizeMessage(action clientMessageStateAction) {
 
 func (c *client) Maximize() {
 	c.maximizeMessage(clientMessageStateActionAdd)
-	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_VERT")
-	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
 }
 
 func (c *client) Unmaximize() {
 	c.maximizeMessage(clientMessageStateActionRemove)
-	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_VERT")
-	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
 }
 
 func (c *client) Focus() {
@@ -243,28 +237,28 @@ func (c *client) unfullscreenClient() {
 func (c *client) iconifyClient() {
 	c.frame.iconifyApply()
 	c.iconic = true
+	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_HIDDEN")
 }
 
 func (c *client) uniconifyClient() {
 	c.newFrame()
 	c.frame.uniconifyApply()
 	c.iconic = false
+	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_HIDDEN")
 }
 
 func (c *client) maximizeClient() {
-	//This is hack to make unmaximizing with Chromium work since Chromium
-	//only sends the add signal for both maximize/unmaximize
-	if c.maximized {
-		c.unmaximizeClient()
-		return
-	}
 	c.maximized = true
 	c.frame.maximizeApply()
+	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_VERT")
+	windowExtendedHintsAdd(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
 }
 
 func (c *client) unmaximizeClient() {
 	c.maximized = false
 	c.frame.unmaximizeApply()
+	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_VERT")
+	windowExtendedHintsRemove(c.wm.x, c.win, "_NET_WM_STATE_MAXIMIZED_HORZ")
 }
 
 func (c *client) setWindowGeometry(x int16, y int16, width uint16, height uint16) {

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -356,8 +356,7 @@ func (x *x11WM) handleClientMessage(ev xproto.ClientMessageEvent) {
 		return
 	}
 	switch msgAtom {
-	//For some reason Chromium uses WM_CHANGE_STATE instead of WM_STATE_CHANGE
-	case "WM_STATE_CHANGE", "WM_CHANGE_STATE":
+	case "WM_CHANGE_STATE":
 		switch ev.Data.Bytes()[0] {
 		case icccm.StateIconic:
 			c.(*client).iconifyClient()

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -3,11 +3,12 @@
 package wm
 
 import (
+	"image"
+
 	"fyne.io/fyne"
 	"fyne.io/fyne/test"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/tools/playground"
-	"image"
 
 	"github.com/BurntSushi/xgb/xproto"
 	"github.com/BurntSushi/xgbutil/xwindow"
@@ -174,6 +175,10 @@ func (f *frame) getInnerWindowCoordinates(x int16, y int16, w uint16, h uint16, 
 		uint32(f.width - borderWidth), uint32(f.height - borderHeight)
 }
 
+func (f *frame) getGeometry() (int16, int16, uint16, uint16) {
+	return f.x, f.y, f.width, f.height
+}
+
 func (f *frame) updateGeometry(x, y int16, w, h uint16) {
 	resize := w != f.width || h != f.height
 	move := x != f.x || y != f.y
@@ -192,6 +197,9 @@ func (f *frame) updateGeometry(x, y int16, w, h uint16) {
 		if err != nil {
 			fyne.LogError("Configure Window Error", err)
 		}
+	} else {
+		f.width = w
+		f.height = h
 	}
 	err := xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.id, xproto.ConfigWindowX|xproto.ConfigWindowY|
 		xproto.ConfigWindowWidth|xproto.ConfigWindowHeight,
@@ -380,7 +388,8 @@ func newFrameBorderless(c *client) *frame {
 	}
 
 	c.id = c.win
-	unframed := &frame{client: c, x: attrs.X, y: attrs.Y, framed: false}
+	unframed := &frame{client: c, x: attrs.X, y: attrs.Y,
+		width: attrs.Width, height: attrs.Height, framed: false}
 	unframed.show()
 
 	return unframed


### PR DESCRIPTION
Chromium, gtk3, and others use their own borders and titlebars and request movement and resizing via extended window manager hints.  This handles those hints to allow the window manager to move and resize those windows.

Fixes #23