### PR TITLE
Implement XRandR Multihead Support - Fix Gnome Apps - Scale Desktops

### DIFF
--- a/cmd/fynedesk/main.go
+++ b/cmd/fynedesk/main.go
@@ -1,27 +1,12 @@
 package main
 
 import (
-	"os"
-
-	"fyne.io/fyne"
 	"fyne.io/fyne/app"
 )
-
-func startSettingsListener(app fyne.App, listener chan fyne.Settings) {
-	for {
-		_ = <-listener
-		if os.Getenv("FYNE_DESK_RUNNER") != "" {
-			os.Exit(1)
-		}
-	}
-}
 
 func main() {
 	a := app.NewWithID("io.fyne.desktop")
 	desk := setupDesktop(a)
-	listener := make(chan fyne.Settings)
-	a.Settings().AddChangeListener(listener)
-	go startSettingsListener(a, listener)
 
 	desk.Run()
 }

--- a/cmd/fynedesk/main.go
+++ b/cmd/fynedesk/main.go
@@ -1,12 +1,27 @@
 package main
 
 import (
+	"os"
+
+	"fyne.io/fyne"
 	"fyne.io/fyne/app"
 )
+
+func startSettingsListener(app fyne.App, listener chan fyne.Settings) {
+	for {
+		_ = <-listener
+		if os.Getenv("FYNE_DESK_RUNNER") != "" {
+			os.Exit(1)
+		}
+	}
+}
 
 func main() {
 	a := app.NewWithID("io.fyne.desktop")
 	desk := setupDesktop(a)
+	listener := make(chan fyne.Settings)
+	a.Settings().AddChangeListener(listener)
+	go startSettingsListener(a, listener)
 
 	desk.Run()
 }

--- a/cmd/fynedesk/main_linux.go
+++ b/cmd/fynedesk/main_linux.go
@@ -14,12 +14,12 @@ import (
 
 func setupDesktop(a fyne.App) desktop.Desktop {
 	icons := internal.NewFDOIconProvider()
-	mgr, err := wm.NewX11WindowManager(a)
+	mgr, screensProvider, err := wm.NewX11WindowManager(a)
 	if err != nil {
 		log.Println("Could not create window manager:", err)
 		return desktop.NewEmbeddedDesktop(a, icons)
 	}
-	desk := desktop.NewDesktop(a, mgr, icons, mgr.(desktop.Screens))
+	desk := desktop.NewDesktop(a, mgr, icons, screensProvider)
 	mgr.SetRoot(desk.Root())
 	return desk
 }

--- a/cmd/fynedesk/main_linux.go
+++ b/cmd/fynedesk/main_linux.go
@@ -14,12 +14,12 @@ import (
 
 func setupDesktop(a fyne.App) desktop.Desktop {
 	icons := internal.NewFDOIconProvider()
-	mgr, screensProvider, err := wm.NewX11WindowManager(a)
+	mgr, err := wm.NewX11WindowManager(a)
 	if err != nil {
 		log.Println("Could not create window manager:", err)
 		return desktop.NewEmbeddedDesktop(a, icons)
 	}
-	desk := desktop.NewDesktop(a, mgr, icons, screensProvider)
+	desk := desktop.NewDesktop(a, mgr, icons, wm.NewX11ScreensProvider(mgr))
 	mgr.SetRoot(desk.Root())
 	return desk
 }

--- a/cmd/fynedesk/main_linux.go
+++ b/cmd/fynedesk/main_linux.go
@@ -19,8 +19,7 @@ func setupDesktop(a fyne.App) desktop.Desktop {
 		log.Println("Could not create window manager:", err)
 		return desktop.NewEmbeddedDesktop(a, icons)
 	}
-
-	desk := desktop.NewDesktop(a, mgr, icons)
+	desk := desktop.NewDesktop(a, mgr, icons, mgr.(desktop.Screens))
 	mgr.SetRoot(desk.Root())
 	return desk
 }

--- a/desk.go
+++ b/desk.go
@@ -9,13 +9,13 @@ import (
 	"fyne.io/fyne"
 )
 
-// Desktop defines an embedded or full desktop envionment that we can run.
+// Desktop defines an embedded or full desktop environment that we can run.
 type Desktop interface {
 	Root() fyne.Window
 	Run()
 	RunApp(AppData) error
 	Settings() DeskSettings
-	ContentSizePixels() (uint32, uint32)
+	ContentSizePixels(screenIndex int) (uint32, uint32)
 
 	IconProvider() ApplicationProvider
 	WindowManager() WindowManager
@@ -28,21 +28,46 @@ type deskLayout struct {
 	win      fyne.Window
 	wm       WindowManager
 	icons    ApplicationProvider
+	screens  Screens
 	settings DeskSettings
 
-	background, bar, widgets, mouse fyne.CanvasObject
+	backgrounds         []fyne.CanvasObject
+	bar, widgets, mouse fyne.CanvasObject
+	container           *fyne.Container
 }
 
 func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
+	var x, y, w, h, index int = 0, 0, 0, 0, 0
+
+	if l.screens.Screens() != nil && len(l.screens.Screens()) > 1 && len(l.backgrounds) > 1 {
+		screens := l.screens.Screens()
+		index = l.screens.Primary()
+		x, y, w, h = screens[index].ScaledX, screens[index].ScaledY,
+			screens[index].ScaledWidth, screens[index].ScaledHeight
+		size.Width = w
+		size.Height = h
+
+		for i := 0; i < len(screens); i++ {
+			if i == index {
+				continue
+			}
+			xx, yy, ww, hh := screens[i].ScaledX, screens[i].ScaledY, screens[i].ScaledWidth, screens[i].ScaledHeight
+
+			l.backgrounds[i].Move(fyne.NewPos(xx, yy))
+			l.backgrounds[i].Resize(fyne.NewSize(ww, hh))
+		}
+	}
+
 	barHeight := l.bar.MinSize().Height
-	l.bar.Resize(fyne.NewSize(size.Width, barHeight))
-	l.bar.Move(fyne.NewPos(0, size.Height-barHeight))
+	l.bar.Resize(fyne.NewSize(size.Width, y+barHeight))
+	l.bar.Move(fyne.NewPos(x, y+size.Height-barHeight))
 
 	widgetsWidth := l.widgets.MinSize().Width
 	l.widgets.Resize(fyne.NewSize(widgetsWidth, size.Height))
-	l.widgets.Move(fyne.NewPos(size.Width-widgetsWidth, 0))
+	l.widgets.Move(fyne.NewPos(x+size.Width-widgetsWidth, y))
 
-	l.background.Resize(size)
+	l.backgrounds[index].Move(fyne.NewPos(x, y))
+	l.backgrounds[index].Resize(size)
 }
 
 func (l *deskLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
@@ -64,17 +89,22 @@ func (l *deskLayout) Root() fyne.Window {
 	if l.win == nil {
 		l.win = l.newDesktopWindow()
 
-		l.background = newBackground()
+		l.backgrounds = append(l.backgrounds, newBackground())
 		l.bar = newBar(l)
 		l.widgets = newWidgetPanel(l)
 		l.mouse = newMouse()
-		l.win.SetContent(fyne.NewContainerWithLayout(l,
-			l.background,
-			l.bar,
-			l.widgets,
-			mouse,
-		))
+		l.container = fyne.NewContainerWithLayout(l, l.backgrounds[0])
+		if l.screens.Screens() != nil && len(l.screens.Screens()) > 1 {
+			for i := 1; i < len(l.screens.Screens()); i++ {
+				l.backgrounds = append(l.backgrounds, newBackground())
+				l.container.AddObject(l.backgrounds[i])
+			}
+		}
+		l.container.AddObject(l.bar)
+		l.container.AddObject(l.widgets)
+		l.container.AddObject(mouse)
 
+		l.win.SetContent(l.container)
 		l.mouse.Hide() // temporarily we do not handle mouse (using X default)
 		if l.wm != nil {
 			l.win.SetOnClosed(func() {
@@ -110,10 +140,16 @@ func (l *deskLayout) Settings() DeskSettings {
 	return l.settings
 }
 
-func (l *deskLayout) ContentSizePixels() (uint32, uint32) {
-	screenW := uint32(float32(l.background.Size().Width) * l.Root().Canvas().Scale())
-	screenH := uint32(float32(l.background.Size().Height) * l.Root().Canvas().Scale())
-	return screenW - uint32(float32(l.widgets.Size().Width)*l.Root().Canvas().Scale()), screenH
+func (l *deskLayout) ContentSizePixels(screenIndex int) (uint32, uint32) {
+	if l.backgrounds[screenIndex] != nil {
+		screenW := uint32(l.backgrounds[screenIndex].Size().Width)
+		screenH := uint32(l.backgrounds[screenIndex].Size().Height)
+		if l.screens.Primary() == screenIndex {
+			return screenW - uint32(float32(l.widgets.Size().Width)*l.Root().Canvas().Scale()), screenH
+		}
+		return screenW, screenH
+	}
+	return 0, 0
 }
 
 func (l *deskLayout) IconProvider() ApplicationProvider {
@@ -134,6 +170,24 @@ func (l *deskLayout) scaleVars(scale float32) []string {
 	}
 }
 
+func (l *deskLayout) Screens() []Screen {
+	if l.app == nil {
+		return nil
+	}
+	return []Screen{{"Screen0", 0, 0, 0,
+		int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
+		0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
+		int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
+}
+
+func (l *deskLayout) Active() int {
+	return 0
+}
+
+func (l *deskLayout) Primary() int {
+	return 0
+}
+
 // Instance returns the current desktop environment and provides access to injected functionality.
 func Instance() Desktop {
 	return instance
@@ -142,8 +196,8 @@ func Instance() Desktop {
 // NewDesktop creates a new desktop in fullscreen for main usage.
 // The WindowManager passed in will be used to manage the screen it is loaded on.
 // An ApplicationProvider is used to lookup application icons from the operating system.
-func NewDesktop(app fyne.App, wm WindowManager, icons ApplicationProvider) Desktop {
-	instance = &deskLayout{app: app, wm: wm, icons: icons, settings: NewDeskSettings()}
+func NewDesktop(app fyne.App, wm WindowManager, icons ApplicationProvider, screens Screens) Desktop {
+	instance = &deskLayout{app: app, wm: wm, icons: icons, screens: screens, settings: NewDeskSettings()}
 	return instance
 }
 
@@ -153,5 +207,6 @@ func NewDesktop(app fyne.App, wm WindowManager, icons ApplicationProvider) Deskt
 // fyne/test package.
 func NewEmbeddedDesktop(app fyne.App, icons ApplicationProvider) Desktop {
 	instance = &deskLayout{app: app, icons: icons, settings: NewDeskSettings()}
+	instance.(*deskLayout).screens = instance.(*deskLayout)
 	return instance
 }

--- a/desk.go
+++ b/desk.go
@@ -47,6 +47,11 @@ func applyScale(coord int, scale float32) int {
 	return newCoord
 }
 
+func removeScale(coord int, scale float32) int {
+	newCoord := int(math.Round(float64(coord) * float64(scale)))
+	return newCoord
+}
+
 func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
 	screens := l.screens.Screens()
 	primary := l.screens.Primary()
@@ -205,7 +210,8 @@ func (esp embeddedScreensProvider) Screens() []*Screen {
 	l := Instance().(*deskLayout)
 	if esp.screens == nil {
 		esp.screens = []*Screen{{"Screen0", 0, 0,
-			int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height)}}
+			removeScale(int(l.Root().Canvas().Size().Width), esp.Scale()),
+			removeScale(int(l.Root().Canvas().Size().Height), esp.Scale())}}
 	}
 	return esp.screens
 }

--- a/desk.go
+++ b/desk.go
@@ -15,7 +15,7 @@ type Desktop interface {
 	Run()
 	RunApp(AppData) error
 	Settings() DeskSettings
-	ContentSizePixels(screen *Screen) (uint32, uint32)
+	ContentSizePixels(screen *Head) (uint32, uint32)
 
 	IconProvider() ApplicationProvider
 	WindowManager() WindowManager
@@ -34,7 +34,7 @@ type deskLayout struct {
 	backgrounds         []fyne.CanvasObject
 	bar, widgets, mouse fyne.CanvasObject
 	container           *fyne.Container
-	screenBackgroundMap map[*Screen]fyne.CanvasObject
+	screenBackgroundMap map[*Head]fyne.CanvasObject
 }
 
 func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
@@ -149,10 +149,10 @@ func (l *deskLayout) Settings() DeskSettings {
 	return l.settings
 }
 
-func (l *deskLayout) ContentSizePixels(screen *Screen) (uint32, uint32) {
-	screenW := uint32(screen.Width)
-	screenH := uint32(screen.Height)
-	if l.screens.Primary() == screen {
+func (l *deskLayout) ContentSizePixels(head *Head) (uint32, uint32) {
+	screenW := uint32(head.Width)
+	screenH := uint32(head.Height)
+	if l.screens.Primary() == head {
 		return screenW - uint32(float32(l.widgets.Size().Width)*l.Root().Canvas().Scale()), screenH
 	}
 	return screenW, screenH
@@ -176,26 +176,30 @@ func (l *deskLayout) scaleVars(scale float32) []string {
 	}
 }
 
-func (l *deskLayout) Screens() []*Screen {
+func (l *deskLayout) Screens() []*Head {
 	if l.app == nil {
 		return nil
 	}
-	return []*Screen{{"Screen0", 0, 0, 0,
+	return []*Head{{"Screen0", 0, 0,
 		int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
 		0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
 		int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
 }
 
-func (l *deskLayout) Active() *Screen {
+func (l *deskLayout) Active() *Head {
 	return l.Screens()[0]
 }
 
-func (l *deskLayout) Primary() *Screen {
+func (l *deskLayout) Primary() *Head {
 	return l.Screens()[0]
 }
 
 func (l *deskLayout) Scale() float32 {
 	return l.Root().Canvas().Scale()
+}
+
+func (l *deskLayout) ScreenForWindow(windwoX int, windowY int) *Head {
+	return l.Screens()[0]
 }
 
 // Instance returns the current desktop environment and provides access to injected functionality.
@@ -208,7 +212,7 @@ func Instance() Desktop {
 // An ApplicationProvider is used to lookup application icons from the operating system.
 func NewDesktop(app fyne.App, wm WindowManager, icons ApplicationProvider, screens Screens) Desktop {
 	instance = &deskLayout{app: app, wm: wm, icons: icons, screens: screens, settings: NewDeskSettings()}
-	instance.(*deskLayout).screenBackgroundMap = make(map[*Screen]fyne.CanvasObject)
+	instance.(*deskLayout).screenBackgroundMap = make(map[*Head]fyne.CanvasObject)
 	return instance
 }
 
@@ -219,6 +223,6 @@ func NewDesktop(app fyne.App, wm WindowManager, icons ApplicationProvider, scree
 func NewEmbeddedDesktop(app fyne.App, icons ApplicationProvider) Desktop {
 	instance = &deskLayout{app: app, icons: icons, settings: NewDeskSettings()}
 	instance.(*deskLayout).screens = instance.(*deskLayout)
-	instance.(*deskLayout).screenBackgroundMap = make(map[*Screen]fyne.CanvasObject)
+	instance.(*deskLayout).screenBackgroundMap = make(map[*Head]fyne.CanvasObject)
 	return instance
 }

--- a/desk.go
+++ b/desk.go
@@ -39,15 +39,13 @@ type deskLayout struct {
 }
 
 type embeddedScreensProvider struct {
+	screens []*Screen
 }
 
 func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
 	var x, y, w, h int = 0, 0, 0, 0
 	screens := l.screens.Screens()
 	primary := l.screens.Primary()
-	if l.Root().Canvas().Scale() != l.screens.Scale() {
-		l.Root().Canvas().SetScale(l.screens.Scale())
-	}
 	x, y, w, h = primary.ScaledX, primary.ScaledY,
 		primary.ScaledWidth, primary.ScaledHeight
 	size.Width = w
@@ -104,6 +102,10 @@ func (l *deskLayout) newDesktopWindow() fyne.Window {
 func (l *deskLayout) Root() fyne.Window {
 	if l.win == nil {
 		l.win = l.newDesktopWindow()
+
+		if l.win.Canvas().Scale() != l.screens.Scale() {
+			l.win.Canvas().SetScale(l.screens.Scale())
+		}
 
 		l.backgrounds = append(l.backgrounds, newBackground())
 		l.screenBackgroundMap[l.screens.Screens()[0]] = l.backgrounds[0]
@@ -191,14 +193,14 @@ func (l *deskLayout) Screens() ScreenList {
 }
 
 func (esp embeddedScreensProvider) Screens() []*Screen {
-	l := instance.(*deskLayout)
-	if l.app == nil {
-		return nil
+	l := Instance().(*deskLayout)
+	if esp.screens == nil {
+		esp.screens = []*Screen{{"Screen0", 0, 0,
+			int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
+			0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
+			int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
 	}
-	return []*Screen{{"Screen0", 0, 0,
-		int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
-		0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
-		int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
+	return esp.screens
 }
 
 func (esp embeddedScreensProvider) Active() *Screen {

--- a/desk.go
+++ b/desk.go
@@ -74,7 +74,12 @@ func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
 	l.widgets.Resize(fyne.NewSize(widgetsWidth, size.Height))
 	l.widgets.Move(fyne.NewPos(x+size.Width-widgetsWidth, y))
 
-	background := l.screenBackgroundMap[primary]
+	var background fyne.CanvasObject
+	if len(screens) > 1 {
+		background = l.screenBackgroundMap[primary]
+	} else {
+		background = l.backgrounds[0]
+	}
 	if background != nil {
 		background.Move(fyne.NewPos(x, y))
 		background.Resize(size)
@@ -191,7 +196,7 @@ func (esp embeddedScreensProvider) Screens() []*Screen {
 		return nil
 	}
 	return []*Screen{{"Screen0", 0, 0,
-		int(instance.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
+		int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
 		0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
 		int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
 }

--- a/desk.go
+++ b/desk.go
@@ -16,6 +16,7 @@ type Desktop interface {
 	RunApp(AppData) error
 	Settings() DeskSettings
 	ContentSizePixels(screen *Screen) (uint32, uint32)
+	Screens() ScreenList
 
 	IconProvider() ApplicationProvider
 	WindowManager() WindowManager
@@ -179,6 +180,11 @@ func (l *deskLayout) scaleVars(scale float32) []string {
 	}
 }
 
+// Screens returns the screens provider of the current desktop environment for access to screen functionality.
+func (l *deskLayout) Screens() ScreenList {
+	return l.screens
+}
+
 func (esp embeddedScreensProvider) Screens() []*Screen {
 	l := instance.(*deskLayout)
 	if l.app == nil {
@@ -202,7 +208,7 @@ func (esp embeddedScreensProvider) Scale() float32 {
 	return instance.(*deskLayout).Root().Canvas().Scale()
 }
 
-func (esp embeddedScreensProvider) ScreenForWindow(windwoX int, windowY int) *Screen {
+func (esp embeddedScreensProvider) ScreenForWindow(win Window) *Screen {
 	return esp.Screens()[0]
 }
 

--- a/desk.go
+++ b/desk.go
@@ -42,12 +42,18 @@ type embeddedScreensProvider struct {
 	screens []*Screen
 }
 
+func applyScale(coord int, scale float32) int {
+	newCoord := int(math.Round(float64(coord) / float64(scale)))
+	return newCoord
+}
+
 func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
-	var x, y, w, h int = 0, 0, 0, 0
 	screens := l.screens.Screens()
 	primary := l.screens.Primary()
-	x, y, w, h = primary.ScaledX, primary.ScaledY,
-		primary.ScaledWidth, primary.ScaledHeight
+	x := applyScale(primary.X, l.screens.Scale())
+	y := applyScale(primary.Y, l.screens.Scale())
+	w := applyScale(primary.Width, l.screens.Scale())
+	h := applyScale(primary.Height, l.screens.Scale())
 	size.Width = w
 	size.Height = h
 	if screens != nil && len(screens) > 1 && len(l.backgrounds) > 1 {
@@ -55,7 +61,10 @@ func (l *deskLayout) Layout(objs []fyne.CanvasObject, size fyne.Size) {
 			if screens[i] == primary {
 				continue
 			}
-			xx, yy, ww, hh := screens[i].ScaledX, screens[i].ScaledY, screens[i].ScaledWidth, screens[i].ScaledHeight
+			xx := applyScale(screens[i].X, l.screens.Scale())
+			yy := applyScale(screens[i].Y, l.screens.Scale())
+			ww := applyScale(screens[i].Width, l.screens.Scale())
+			hh := applyScale(screens[i].Height, l.screens.Scale())
 			background := l.screenBackgroundMap[screens[i]]
 			if background != nil {
 				background.Move(fyne.NewPos(xx, yy))
@@ -196,9 +205,7 @@ func (esp embeddedScreensProvider) Screens() []*Screen {
 	l := Instance().(*deskLayout)
 	if esp.screens == nil {
 		esp.screens = []*Screen{{"Screen0", 0, 0,
-			int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height),
-			0, 0, int(float32(l.Root().Canvas().Size().Width) * l.Root().Canvas().Scale()),
-			int(float32(l.Root().Canvas().Size().Height) * l.Root().Canvas().Scale())}}
+			int(l.Root().Canvas().Size().Width), int(l.Root().Canvas().Size().Height)}}
 	}
 	return esp.screens
 }

--- a/desk_test.go
+++ b/desk_test.go
@@ -28,7 +28,7 @@ func (*testDesk) Settings() DeskSettings {
 	return &testSettings{}
 }
 
-func (*testDesk) ContentSizePixels(screenIndex int) (uint32, uint32) {
+func (*testDesk) ContentSizePixels(screen *Screen) (uint32, uint32) {
 	return uint32(320), uint32(240)
 }
 

--- a/desk_test.go
+++ b/desk_test.go
@@ -61,7 +61,7 @@ type testScreensProvider struct {
 
 func (tsp testScreensProvider) Screens() []*Screen {
 	if tsp.screens == nil {
-		tsp.screens = []*Screen{{"Screen0", 0, 0, 2000, 1000, 0, 0, 2000, 1000}}
+		tsp.screens = []*Screen{{"Screen0", 0, 0, 2000, 1000}}
 	}
 	return tsp.screens
 }

--- a/desk_test.go
+++ b/desk_test.go
@@ -40,6 +40,10 @@ func (*testDesk) WindowManager() WindowManager {
 	return nil
 }
 
+func (*testDesk) Screens() ScreenList {
+	return nil
+}
+
 type testSettings struct {
 }
 
@@ -51,10 +55,44 @@ func (*testSettings) Background() string {
 	return ""
 }
 
+type testScreensProvider struct {
+	screens []*Screen
+}
+
+func (tsp testScreensProvider) Screens() []*Screen {
+	if tsp.screens == nil {
+		tsp.screens = []*Screen{{"Screen0", 0, 0, 2000, 1000, 0, 0, 2000, 1000}}
+	}
+	return tsp.screens
+}
+
+func (tsp testScreensProvider) Active() *Screen {
+	return tsp.Screens()[0]
+}
+
+func (tsp testScreensProvider) Primary() *Screen {
+	return tsp.Screens()[0]
+}
+
+func (tsp testScreensProvider) Scale() float32 {
+	return 1.0
+}
+
+func (tsp testScreensProvider) ScreenForWindow(win Window) *Screen {
+	return tsp.Screens()[0]
+}
+
+func newTestScreensProvider() ScreenList {
+	return &testScreensProvider{}
+}
+
 func TestDeskLayout_Layout(t *testing.T) {
 	l := &deskLayout{}
-	l.screens = NewEmbeddedScreensProvider()
+	instance = l
+	l.screens = newTestScreensProvider()
 	l.backgrounds = []fyne.CanvasObject{canvas.NewRectangle(color.White)}
+	l.screenBackgroundMap = make(map[*Screen]fyne.CanvasObject)
+	l.screenBackgroundMap[l.Screens().Screens()[0]] = l.backgrounds[0]
 	l.bar = canvas.NewRectangle(color.Black)
 	l.widgets = canvas.NewRectangle(color.Black)
 	deskSize := fyne.NewSize(2000, 1000)
@@ -70,7 +108,8 @@ func TestDeskLayout_Layout(t *testing.T) {
 
 func TestScaleVars(t *testing.T) {
 	l := &deskLayout{}
-	l.screens = NewEmbeddedScreensProvider()
+	instance = l
+	l.screens = newTestScreensProvider()
 	env := l.scaleVars(1.8)
 	assert.Contains(t, env, "QT_SCALE_FACTOR=1.8")
 	assert.Contains(t, env, "GDK_SCALE=2")

--- a/desk_test.go
+++ b/desk_test.go
@@ -28,7 +28,7 @@ func (*testDesk) Settings() DeskSettings {
 	return &testSettings{}
 }
 
-func (*testDesk) ContentSizePixels(head *Head) (uint32, uint32) {
+func (*testDesk) ContentSizePixels(screen *Screen) (uint32, uint32) {
 	return uint32(320), uint32(240)
 }
 
@@ -53,8 +53,8 @@ func (*testSettings) Background() string {
 
 func TestDeskLayout_Layout(t *testing.T) {
 	l := &deskLayout{}
-	l.screens = l
-	l.backgrounds = append(l.backgrounds, canvas.NewRectangle(color.White))
+	l.screens = NewEmbeddedScreensProvider()
+	l.backgrounds = []fyne.CanvasObject{canvas.NewRectangle(color.White)}
 	l.bar = canvas.NewRectangle(color.Black)
 	l.widgets = canvas.NewRectangle(color.Black)
 	deskSize := fyne.NewSize(2000, 1000)
@@ -70,7 +70,7 @@ func TestDeskLayout_Layout(t *testing.T) {
 
 func TestScaleVars(t *testing.T) {
 	l := &deskLayout{}
-	l.screens = l
+	l.screens = NewEmbeddedScreensProvider()
 	env := l.scaleVars(1.8)
 	assert.Contains(t, env, "QT_SCALE_FACTOR=1.8")
 	assert.Contains(t, env, "GDK_SCALE=2")

--- a/desk_test.go
+++ b/desk_test.go
@@ -28,7 +28,7 @@ func (*testDesk) Settings() DeskSettings {
 	return &testSettings{}
 }
 
-func (*testDesk) ContentSizePixels(screen *Screen) (uint32, uint32) {
+func (*testDesk) ContentSizePixels(head *Head) (uint32, uint32) {
 	return uint32(320), uint32(240)
 }
 

--- a/desk_test.go
+++ b/desk_test.go
@@ -28,7 +28,7 @@ func (*testDesk) Settings() DeskSettings {
 	return &testSettings{}
 }
 
-func (*testDesk) ContentSizePixels() (uint32, uint32) {
+func (*testDesk) ContentSizePixels(screenIndex int) (uint32, uint32) {
 	return uint32(320), uint32(240)
 }
 
@@ -53,14 +53,15 @@ func (*testSettings) Background() string {
 
 func TestDeskLayout_Layout(t *testing.T) {
 	l := &deskLayout{}
-	l.background = canvas.NewRectangle(color.White)
+	l.screens = l
+	l.backgrounds = append(l.backgrounds, canvas.NewRectangle(color.White))
 	l.bar = canvas.NewRectangle(color.Black)
 	l.widgets = canvas.NewRectangle(color.Black)
 	deskSize := fyne.NewSize(2000, 1000)
 
-	l.Layout([]fyne.CanvasObject{l.background, l.bar, l.widgets}, deskSize)
+	l.Layout([]fyne.CanvasObject{l.backgrounds[0], l.bar, l.widgets}, deskSize)
 
-	assert.Equal(t, l.background.Size(), deskSize)
+	assert.Equal(t, l.backgrounds[0].Size(), deskSize)
 	assert.Equal(t, l.widgets.Position().X+l.widgets.Size().Width, deskSize.Width)
 	assert.Equal(t, l.widgets.Size().Height, deskSize.Height)
 	assert.Equal(t, l.bar.Size().Width, deskSize.Width)
@@ -69,6 +70,7 @@ func TestDeskLayout_Layout(t *testing.T) {
 
 func TestScaleVars(t *testing.T) {
 	l := &deskLayout{}
+	l.screens = l
 	env := l.scaleVars(1.8)
 	assert.Contains(t, env, "QT_SCALE_FACTOR=1.8")
 	assert.Contains(t, env, "GDK_SCALE=2")

--- a/screen.go
+++ b/screen.go
@@ -2,11 +2,11 @@ package desktop
 
 // ScreenList provides information about available physical screens for Fyne desktop
 type ScreenList interface {
-	Screens() []*Screen                               // Screens returns a Screen type slice of each available physical screen
-	Active() *Screen                                  // Active returns the screen index of the currently active screen
-	Primary() *Screen                                 // Primary returns the screen index of the primary screen
-	Scale() float32                                   // Return the scale calculated for use across screens
-	ScreenForWindow(windowX int, windowY int) *Screen // Return the screen that a window is located on
+	Screens() []*Screen             // Screens returns a Screen type slice of each available physical screen
+	Active() *Screen                // Active returns the screen index of the currently active screen
+	Primary() *Screen               // Primary returns the screen index of the primary screen
+	Scale() float32                 // Return the scale calculated for use across screens
+	ScreenForWindow(Window) *Screen // Return the screen that a window is located on
 }
 
 // Screen provides relative information about a single physical screen

--- a/screen.go
+++ b/screen.go
@@ -1,16 +1,16 @@
 package desktop
 
-// Screens provides information about available physical screens for Fyne desktop
-type Screens interface {
-	Screens() []*Head                               // Screens returns a Screen type slice of each available physical screen
-	Active() *Head                                  // Active returns the screen index of the currently active screen
-	Primary() *Head                                 // Primary returns the screen index of the primary screen
-	Scale() float32                                 // Return the scale calculated for use across screens
-	ScreenForWindow(windowX int, windowY int) *Head // Return the screen that a window is located on
+// ScreenList provides information about available physical screens for Fyne desktop
+type ScreenList interface {
+	Screens() []*Screen                               // Screens returns a Screen type slice of each available physical screen
+	Active() *Screen                                  // Active returns the screen index of the currently active screen
+	Primary() *Screen                                 // Primary returns the screen index of the primary screen
+	Scale() float32                                   // Return the scale calculated for use across screens
+	ScreenForWindow(windowX int, windowY int) *Screen // Return the screen that a window is located on
 }
 
-// Head provides relative information about a single physical screen
-type Head struct {
+// Screen provides relative information about a single physical screen
+type Screen struct {
 	Name                      string // Name is the randr provided name of the screen
 	X, Y, Width, Height       int    // Geometry of the screen
 	ScaledX, ScaledY          int    // Scaled position of the screen

--- a/screen.go
+++ b/screen.go
@@ -2,9 +2,10 @@ package desktop
 
 // Screens provides information about available physical screens for Fyne desktop
 type Screens interface {
-	Screens() []Screen // Screens returns a Screen type slice of each available physical screen
-	Active() int       // Active returns the screen index of the currently active screen
-	Primary() int      // Primary returns the screen index of the primary screen
+	Screens() []*Screen // Screens returns a Screen type slice of each available physical screen
+	Active()  *Screen    // Active returns the screen index of the currently active screen
+	Primary() *Screen    // Primary returns the screen index of the primary screen
+	Scale()   float32    // Return the scale calculated for use across screens
 }
 
 // Screen provides relative information about a single physical screen

--- a/screen.go
+++ b/screen.go
@@ -2,16 +2,16 @@ package desktop
 
 // Screens provides information about available physical screens for Fyne desktop
 type Screens interface {
-	Screens() []*Screen // Screens returns a Screen type slice of each available physical screen
-	Active()  *Screen    // Active returns the screen index of the currently active screen
-	Primary() *Screen    // Primary returns the screen index of the primary screen
-	Scale()   float32    // Return the scale calculated for use across screens
+	Screens() []*Head                               // Screens returns a Screen type slice of each available physical screen
+	Active() *Head                                  // Active returns the screen index of the currently active screen
+	Primary() *Head                                 // Primary returns the screen index of the primary screen
+	Scale() float32                                 // Return the scale calculated for use across screens
+	ScreenForWindow(windowX int, windowY int) *Head // Return the screen that a window is located on
 }
 
-// Screen provides relative information about a single physical screen
-type Screen struct {
+// Head provides relative information about a single physical screen
+type Head struct {
 	Name                      string // Name is the randr provided name of the screen
-	Index                     int    // Index is the position of the screen in the screens slice.
 	X, Y, Width, Height       int    // Geometry of the screen
 	ScaledX, ScaledY          int    // Scaled position of the screen
 	ScaledWidth, ScaledHeight int    // Scaled size of the screen

--- a/screen.go
+++ b/screen.go
@@ -1,0 +1,17 @@
+package desktop
+
+// Screens provides information about available physical screens for Fyne desktop
+type Screens interface {
+	Screens() []Screen // Screens returns a Screen type slice of each available physical screen
+	Active() int       // Active returns the screen index of the currently active screen
+	Primary() int      // Primary returns the screen index of the primary screen
+}
+
+// Screen provides relative information about a single physical screen
+type Screen struct {
+	Name                      string // Name is the randr provided name of the screen
+	Index                     int    // Index is the position of the screen in the screens slice.
+	X, Y, Width, Height       int    // Geometry of the screen
+	ScaledX, ScaledY          int    // Scaled position of the screen
+	ScaledWidth, ScaledHeight int    // Scaled size of the screen
+}

--- a/screen.go
+++ b/screen.go
@@ -11,8 +11,6 @@ type ScreenList interface {
 
 // Screen provides relative information about a single physical screen
 type Screen struct {
-	Name                      string // Name is the randr provided name of the screen
-	X, Y, Width, Height       int    // Geometry of the screen
-	ScaledX, ScaledY          int    // Scaled position of the screen
-	ScaledWidth, ScaledHeight int    // Scaled size of the screen
+	Name                string // Name is the randr provided name of the screen
+	X, Y, Width, Height int    // Geometry of the screen
 }

--- a/wm/client.go
+++ b/wm/client.go
@@ -217,6 +217,7 @@ func (c *client) Focus() {
 
 func (c *client) RaiseToTop() {
 	c.wm.RaiseToTop(c)
+	windowClientListStackingSet(c.wm.x, c.wm.getWindowsFromClients(c.wm.clients))
 }
 
 func (c *client) RaiseAbove(win desktop.Window) {
@@ -318,7 +319,6 @@ func newClient(win xproto.Window, wm *x11WM) *client {
 	}
 	windowAllowedActionsSet(wm.x, win, wm.allowedActions)
 	initialHints := windowExtendedHintsGet(c.wm.x, c.win)
-	removeHints := wm.pendingRemoveHints[win]
 	for _, hint := range initialHints {
 		switch hint {
 		case "_NET_WM_STATE_FULLSCREEN":
@@ -326,14 +326,7 @@ func newClient(win xproto.Window, wm *x11WM) *client {
 		}
 		// TODO Handle more of these possible hints
 	}
-	for _, hint := range removeHints {
-		switch hint {
-		case "_NET_WM_STATE_HIDDEN":
-			c.uniconifyClient()
-		}
-		windowExtendedHintsRemove(wm.x, win, hint)
-		delete(wm.pendingRemoveHints, win)
-	}
+
 	c.newFrame()
 
 	return c

--- a/wm/client.go
+++ b/wm/client.go
@@ -225,7 +225,7 @@ func (c *client) Focus() {
 
 func (c *client) RaiseToTop() {
 	c.wm.RaiseToTop(c)
-	windowClientListStackingSet(c.wm.x, c.wm.getWindowsFromClients(c.wm.clients))
+	windowClientListStackingUpdate(c.wm)
 }
 
 func (c *client) RaiseAbove(win desktop.Window) {

--- a/wm/client.go
+++ b/wm/client.go
@@ -35,6 +35,14 @@ type client struct {
 	wm    *x11WM
 }
 
+func (s *stack) getWindowsFromClients(clients []desktop.Window) []xproto.Window {
+	var wins []xproto.Window
+	for _, cli := range clients {
+		wins = append(wins, cli.(*client).id)
+	}
+	return wins
+}
+
 func (s *stack) clientForWin(id xproto.Window) desktop.Window {
 	for _, w := range s.clients {
 		if w.(*client).id == id || w.(*client).win == id {
@@ -318,13 +326,16 @@ func newClient(win xproto.Window, wm *x11WM) *client {
 		fyne.LogError("Could not change window attributes", err)
 	}
 	windowAllowedActionsSet(wm.x, win, wm.allowedActions)
+
 	initialHints := windowExtendedHintsGet(c.wm.x, c.win)
 	for _, hint := range initialHints {
 		switch hint {
 		case "_NET_WM_STATE_FULLSCREEN":
 			c.full = true
+		case "_NET_WM_STATE_MAXIMIZED_VERT", "_NET_WM_STATE_MAXIMIZED_HORZ":
+			c.maximized = true
+			// TODO Handle more of these possible hints
 		}
-		// TODO Handle more of these possible hints
 	}
 
 	c.newFrame()

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -22,17 +22,19 @@ import (
 
 type x11WM struct {
 	stack
-	x                  *xgbutil.XUtil
-	root               fyne.Window
-	rootID             xproto.Window
-	loaded             bool
-	moveResizing       bool
-	moveResizingLastX  int16
-	moveResizingLastY  int16
-	moveResizingType   moveResizeType
-	pendingRemoveHints map[xproto.Window][]string
-	altTabList         []desktop.Window
-	altTabIndex        int
+	x                 *xgbutil.XUtil
+	root              fyne.Window
+	rootID            xproto.Window
+	loaded            bool
+	moveResizing      bool
+	moveResizingLastX int16
+	moveResizingLastY int16
+	moveResizingType  moveResizeType
+	altTabList        []desktop.Window
+	altTabIndex       int
+	screens           []desktop.Screen
+	active            int
+	primary           int
 
 	allowedActions []string
 	supportedHints []string
@@ -80,6 +82,18 @@ func (x *x11WM) Blank() {
 	exec.Command("xset", "-display", os.Getenv("DISPLAY"), "dpms", "force", "off").Start()
 }
 
+func (x *x11WM) Screens() []desktop.Screen {
+	return x.screens
+}
+
+func (x *x11WM) Active() int {
+	return x.active
+}
+
+func (x *x11WM) Primary() int {
+	return x.primary
+}
+
 // NewX11WindowManager sets up a new X11 Window Manager to control a desktop in X11.
 func NewX11WindowManager(a fyne.App) (desktop.WindowManager, error) {
 	conn, err := xgbutil.NewConn()
@@ -89,7 +103,6 @@ func NewX11WindowManager(a fyne.App) (desktop.WindowManager, error) {
 	}
 
 	mgr := &x11WM{x: conn}
-	mgr.pendingRemoveHints = make(map[xproto.Window][]string)
 	root := conn.RootWin()
 	eventMask := xproto.EventMaskPropertyChange |
 		xproto.EventMaskFocusChange |
@@ -118,7 +131,10 @@ func NewX11WindowManager(a fyne.App) (desktop.WindowManager, error) {
 	}
 
 	mgr.supportedHints = append(mgr.supportedHints, mgr.allowedActions...)
-	mgr.supportedHints = append(mgr.supportedHints, "_NET_WM_STATE",
+	mgr.supportedHints = append(mgr.supportedHints, "_NET_SUPPORTED",
+		"_NET_CLIENT_LIST",
+		"_NET_CLIENT_LIST_STACKING",
+		"_NET_WM_STATE",
 		"_NET_WM_STATE_MAXIMIZED_VERT",
 		"_NET_WM_STATE_MAXIMIZED_HORZ",
 		"_NET_WM_STATE_SKIP_TASKBAR",
@@ -126,15 +142,17 @@ func NewX11WindowManager(a fyne.App) (desktop.WindowManager, error) {
 		"_NET_WM_STATE_HIDDEN",
 		"_NET_WM_STATE_FULLSCREEN",
 		"_NET_FRAME_EXTENTS",
+		"_NET_WM_MOVERESIZE",
 		"_NET_WM_NAME",
 		"_NET_WM_FULLSCREEN_MONITORS",
-		"_NET_MOVERESIZE_WINDOW",
-		"_NET_SUPPORTED")
+		"_NET_MOVERESIZE_WINDOW")
 
 	ewmh.SupportedSet(mgr.x, mgr.supportedHints)
 	ewmh.SupportingWmCheckSet(mgr.x, mgr.x.RootWin(), mgr.x.Dummy())
 	ewmh.SupportingWmCheckSet(mgr.x, mgr.x.Dummy(), mgr.x.Dummy())
 	ewmh.WmNameSet(mgr.x, mgr.x.Dummy(), "Fyne Desktop")
+
+	mgr.setupScreens()
 
 	loadCursors(conn)
 	go mgr.runLoop()
@@ -259,6 +277,7 @@ func (x *x11WM) runLoop() {
 			}
 
 			x.RaiseToTop(x.altTabList[x.altTabIndex])
+			windowClientListStackingSet(x.x, x.getWindowsFromClients(x.clients))
 		case xproto.KeyReleaseEvent:
 			if ev.Detail == keyCodeAlt {
 				x.altTabList = nil
@@ -277,7 +296,7 @@ func (x *x11WM) configureWindow(win xproto.Window, ev xproto.ConfigureRequestEve
 
 	if c != nil {
 		f := c.(*client).frame
-		if f != nil && c.(*client).win == win { // ignore requests from our frame a we must have caused it
+		if f != nil && c.(*client).win == win { // ignore requests from our frame as we must have caused it
 			f.minWidth, f.minHeight = windowMinSize(x.x, win)
 			if c.Decorated() {
 				err := xproto.ConfigureWindowChecked(x.x.Conn(), win, xproto.ConfigWindowX|xproto.ConfigWindowY|
@@ -431,8 +450,8 @@ func (x *x11WM) handleStateActionRequest(ev xproto.ClientMessageEvent, removeSta
 func (x *x11WM) handleInitialHints(ev xproto.ClientMessageEvent, hint string) {
 	switch clientMessageStateAction(ev.Data.Data32[0]) {
 	case clientMessageStateActionRemove:
-		hints := x.pendingRemoveHints[ev.Window]
-		hints = append(hints, hint)
+		windowExtendedHintsRemove(x.x, ev.Window, hint)
+		x.showWindow(ev.Window)
 	case clientMessageStateActionAdd:
 		windowExtendedHintsAdd(x.x, ev.Window, hint)
 	}
@@ -518,6 +537,18 @@ func (x *x11WM) showWindow(win xproto.Window) {
 	if x.rootID == 0 {
 		return
 	}
+	hints, err := icccm.WmHintsGet(x.x, win)
+	if err != nil {
+		fyne.LogError("Could not get initial hints for client", err)
+	} else {
+		if (hints.Flags & xproto.CwOverrideRedirect) != 0 {
+			return
+		}
+	}
+	transient, err := icccm.WmTransientForGet(x.x, win)
+	if transient != 0 {
+		return
+	}
 
 	x.setupWindow(win)
 }
@@ -527,6 +558,7 @@ func (x *x11WM) hideWindow(win xproto.Window) {
 	if c == nil {
 		return
 	}
+
 	xproto.UnmapWindow(x.x.Conn(), c.(*client).id)
 }
 
@@ -537,10 +569,9 @@ func (x *x11WM) setupWindow(win xproto.Window) {
 	}
 	c := x.clientForWin(win)
 	if c != nil {
-		c.(*client).newFrame()
-	} else {
-		c = newClient(win, x)
+		return
 	}
+	c = newClient(win, x)
 
 	x.bindKeys(win)
 	xproto.GrabButton(x.x.Conn(), true, c.(*client).id,
@@ -552,6 +583,8 @@ func (x *x11WM) setupWindow(win xproto.Window) {
 
 	x.AddWindow(c)
 	c.Focus()
+	windowClientListSet(x.x, x.getMappingOrder())
+	windowClientListStackingSet(x.x, x.getWindowsFromClients(x.clients))
 }
 
 func (x *x11WM) destroyWindow(win xproto.Window) {
@@ -560,6 +593,8 @@ func (x *x11WM) destroyWindow(win xproto.Window) {
 		return
 	}
 	x.RemoveWindow(c)
+	windowClientListSet(x.x, x.getMappingOrder())
+	windowClientListStackingSet(x.x, x.getWindowsFromClients(x.clients))
 }
 
 func (x *x11WM) bindKeys(win xproto.Window) {

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -238,27 +238,13 @@ func (f *frame) maximizeApply() {
 	f.client.restoreX = f.x
 	f.client.restoreY = f.y
 
-	var startX, startY int = 0, 0
-	var screen *desktop.Screen
-	screens := f.client.wm.Screens()
-	if len(screens) > 1 {
-		for i := 0; i < len(screens); i++ {
-			x, y, w, h := screens[i].X, screens[i].Y, screens[i].Width, screens[i].Height
-			if int(f.x) >= x && int(f.y) >= y &&
-				int(f.x) <= x+w && int(f.y) <= y+h {
-				screen = screens[i]
-				startX = x
-				startY = y
-				break
-			}
-		}
-	}
-	maxWidth, maxHeight := desktop.Instance().ContentSizePixels(screen)
+	head := f.client.wm.ScreenForWindow(int(f.x), int(f.y))
+	maxWidth, maxHeight := desktop.Instance().ContentSizePixels(head)
 	if f.client.Fullscreened() {
-		maxWidth = uint32(screen.Width)
-		maxHeight = uint32(screen.Height)
+		maxWidth = uint32(head.Width)
+		maxHeight = uint32(head.Height)
 	}
-	f.updateGeometry(int16(startX), int16(startY), uint16(maxWidth), uint16(maxHeight), true)
+	f.updateGeometry(int16(head.X), int16(head.Y), uint16(maxWidth), uint16(maxHeight), true)
 }
 
 func (f *frame) unmaximizeApply() {
@@ -480,10 +466,11 @@ func newFrame(c *client) *frame {
 	full := c.Fullscreened()
 	decorated := c.Decorated()
 	if full {
-		x = int16(c.wm.Active().X)
-		y = int16(c.wm.Active().Y)
-		w = uint16(c.wm.Active().Width)
-		h = uint16(c.wm.Active().Height)
+		activeHead := c.wm.Active()
+		x = int16(activeHead.X)
+		y = int16(activeHead.Y)
+		w = uint16(activeHead.Width)
+		h = uint16(activeHead.Height)
 	} else if !decorated {
 		x = attrs.X
 		y = attrs.Y

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -238,7 +238,7 @@ func (f *frame) maximizeApply() {
 	f.client.restoreX = f.x
 	f.client.restoreY = f.y
 
-	head := f.client.wm.ScreenForWindow(int(f.x), int(f.y))
+	head := f.client.wm.screensProvider.ScreenForWindow(int(f.x), int(f.y))
 	maxWidth, maxHeight := desktop.Instance().ContentSizePixels(head)
 	if f.client.Fullscreened() {
 		maxWidth = uint32(head.Width)
@@ -248,6 +248,11 @@ func (f *frame) maximizeApply() {
 }
 
 func (f *frame) unmaximizeApply() {
+	if f.client.restoreWidth == 0 && f.client.restoreHeight == 0 {
+		screen := f.client.wm.screensProvider.ScreenForWindow(int(f.client.restoreX), int(f.client.restoreY))
+		f.client.restoreWidth = uint16(screen.Width / 2)
+		f.client.restoreHeight = uint16(screen.Height / 2)
+	}
 	f.updateGeometry(f.client.restoreX, f.client.restoreY, f.client.restoreWidth, f.client.restoreHeight, true)
 }
 
@@ -466,7 +471,7 @@ func newFrame(c *client) *frame {
 	full := c.Fullscreened()
 	decorated := c.Decorated()
 	if full {
-		activeHead := c.wm.Active()
+		activeHead := c.wm.screensProvider.Active()
 		x = int16(activeHead.X)
 		y = int16(activeHead.Y)
 		w = uint16(activeHead.Width)
@@ -503,7 +508,7 @@ func newFrame(c *client) *frame {
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: int(framed.borderWidth()), Right: int(framed.borderWidth()), Top: int(framed.titleHeight()), Bottom: int(framed.borderWidth())})
 	} else {
 		xproto.ReparentWindow(c.wm.x.Conn(), c.win, c.id,
-			int16(c.wm.Active().X), int16(c.wm.Active().Y))
+			int16(c.wm.screensProvider.Active().X), int16(c.wm.screensProvider.Active().Y))
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: 0, Right: 0, Top: 0, Bottom: 0})
 	}
 

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -201,15 +201,15 @@ func (f *frame) updateGeometry(x, y int16, w, h uint16, force bool) {
 	newx, newy, neww, newh = f.getInnerWindowCoordinates(x, y, w, h)
 	f.applyTheme(false)
 
-	err := xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.win, xproto.ConfigWindowX|xproto.ConfigWindowY|
+	err := xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.id, xproto.ConfigWindowX|xproto.ConfigWindowY|
 		xproto.ConfigWindowWidth|xproto.ConfigWindowHeight,
-		[]uint32{uint32(newx), uint32(newy), neww, newh}).Check()
+		[]uint32{uint32(f.x), uint32(f.y), uint32(f.width), uint32(f.height)}).Check()
 	if err != nil {
 		fyne.LogError("Configure Window Error", err)
 	}
-	err = xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.id, xproto.ConfigWindowX|xproto.ConfigWindowY|
+	err = xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.win, xproto.ConfigWindowX|xproto.ConfigWindowY|
 		xproto.ConfigWindowWidth|xproto.ConfigWindowHeight,
-		[]uint32{uint32(f.x), uint32(f.y), uint32(f.width), uint32(f.height)}).Check()
+		[]uint32{newx, newy, neww, newh}).Check()
 	if err != nil {
 		fyne.LogError("Configure Window Error", err)
 	}
@@ -221,12 +221,26 @@ func (f *frame) maximizeApply() {
 	f.client.restoreX = f.x
 	f.client.restoreY = f.y
 
-	maxWidth, maxHeight := desktop.Instance().ContentSizePixels()
-	if f.client.Fullscreened() {
-		maxWidth = uint32(f.client.wm.x.Screen().WidthInPixels)
-		maxHeight = uint32(f.client.wm.x.Screen().HeightInPixels)
+	var screenIndex, startX, startY int = 0, 0, 0
+	screens := f.client.wm.Screens()
+	if len(screens) > 1 {
+		for i := 0; i < len(screens); i++ {
+			x, y, w, h := screens[i].X, screens[i].Y, screens[i].Width, screens[i].Height
+			if int(f.x) >= x && int(f.y) >= y &&
+				int(f.x) <= x+w && int(f.y) <= y+h {
+				screenIndex = i
+				startX = x
+				startY = y
+				break
+			}
+		}
 	}
-	f.updateGeometry(0, 0, uint16(maxWidth), uint16(maxHeight), true)
+	maxWidth, maxHeight := desktop.Instance().ContentSizePixels(screenIndex)
+	if f.client.Fullscreened() {
+		maxWidth = uint32(screens[screenIndex].Width)
+		maxHeight = uint32(screens[screenIndex].Height)
+	}
+	f.updateGeometry(int16(startX), int16(startY), uint16(maxWidth), uint16(maxHeight), true)
 }
 
 func (f *frame) unmaximizeApply() {
@@ -353,12 +367,9 @@ func (f *frame) applyBorderlessTheme() {
 		rect := xproto.Rectangle{X: 0, Y: 0, Width: f.width, Height: f.height}
 		xproto.PolyFillRectangleChecked(f.client.wm.x.Conn(), xproto.Drawable(f.client.id), draw, []xproto.Rectangle{rect})
 	}
-	if !f.client.Fullscreened() {
-		return
-	}
 	err := xproto.ConfigureWindowChecked(f.client.wm.x.Conn(), f.client.win, xproto.ConfigWindowX|xproto.ConfigWindowY|
 		xproto.ConfigWindowWidth|xproto.ConfigWindowHeight,
-		[]uint32{uint32(f.x), uint32(f.y), uint32(f.width), uint32(f.height)}).Check()
+		[]uint32{uint32(0), uint32(0), uint32(f.width), uint32(f.height)}).Check()
 	if err != nil {
 		fyne.LogError("Configure Window Error", err)
 	}
@@ -451,10 +462,10 @@ func newFrame(c *client) *frame {
 	full := c.Fullscreened()
 	decorated := c.Decorated()
 	if full {
-		x = 0
-		y = 0
-		w = c.wm.x.Screen().WidthInPixels
-		h = c.wm.x.Screen().HeightInPixels
+		x = int16(c.wm.Screens()[c.wm.Active()].X)
+		y = int16(c.wm.Screens()[c.wm.Active()].Y)
+		w = uint16(c.wm.Screens()[c.wm.Active()].Width)
+		h = uint16(c.wm.Screens()[c.wm.Active()].Height)
 	} else if !decorated {
 		x = attrs.X
 		y = attrs.Y
@@ -486,7 +497,8 @@ func newFrame(c *client) *frame {
 		xproto.ReparentWindow(c.wm.x.Conn(), c.win, c.id, int16(framed.borderWidth()), int16(framed.titleHeight()))
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: int(framed.borderWidth()), Right: int(framed.borderWidth()), Top: int(framed.titleHeight()), Bottom: int(framed.borderWidth())})
 	} else {
-		xproto.ReparentWindow(c.wm.x.Conn(), c.win, c.id, 0, 0)
+		xproto.ReparentWindow(c.wm.x.Conn(), c.win, c.id,
+			int16(c.wm.Screens()[c.wm.Active()].X), int16(c.wm.Screens()[c.wm.Active()].Y))
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: 0, Right: 0, Top: 0, Bottom: 0})
 	}
 	framed.show()

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -238,7 +238,7 @@ func (f *frame) maximizeApply() {
 	f.client.restoreX = f.x
 	f.client.restoreY = f.y
 
-	head := f.client.wm.screensProvider.ScreenForWindow(int(f.x), int(f.y))
+	head := desktop.Instance().Screens().ScreenForWindow(f.client)
 	maxWidth, maxHeight := desktop.Instance().ContentSizePixels(head)
 	if f.client.Fullscreened() {
 		maxWidth = uint32(head.Width)
@@ -249,7 +249,7 @@ func (f *frame) maximizeApply() {
 
 func (f *frame) unmaximizeApply() {
 	if f.client.restoreWidth == 0 && f.client.restoreHeight == 0 {
-		screen := f.client.wm.screensProvider.ScreenForWindow(int(f.client.restoreX), int(f.client.restoreY))
+		screen := desktop.Instance().Screens().ScreenForWindow(f.client)
 		f.client.restoreWidth = uint16(screen.Width / 2)
 		f.client.restoreHeight = uint16(screen.Height / 2)
 	}
@@ -471,7 +471,7 @@ func newFrame(c *client) *frame {
 	full := c.Fullscreened()
 	decorated := c.Decorated()
 	if full {
-		activeHead := c.wm.screensProvider.Active()
+		activeHead := desktop.Instance().Screens().Active()
 		x = int16(activeHead.X)
 		y = int16(activeHead.Y)
 		w = uint16(activeHead.Width)
@@ -508,7 +508,7 @@ func newFrame(c *client) *frame {
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: int(framed.borderWidth()), Right: int(framed.borderWidth()), Top: int(framed.titleHeight()), Bottom: int(framed.borderWidth())})
 	} else {
 		xproto.ReparentWindow(c.wm.x.Conn(), c.win, c.id,
-			int16(c.wm.screensProvider.Active().X), int16(c.wm.screensProvider.Active().Y))
+			int16(desktop.Instance().Screens().Active().X), int16(desktop.Instance().Screens().Active().Y))
 		ewmh.FrameExtentsSet(c.wm.x, c.win, &ewmh.FrameExtents{Left: 0, Right: 0, Top: 0, Bottom: 0})
 	}
 

--- a/wm/property.go
+++ b/wm/property.go
@@ -158,3 +158,11 @@ func windowExtendedHintsRemove(x *xgbutil.XUtil, win xproto.Window, hint string)
 		}
 	}
 }
+
+func windowClientListSet(x *xgbutil.XUtil, wins []xproto.Window) {
+	ewmh.ClientListSet(x, wins)
+}
+
+func windowClientListStackingSet(x *xgbutil.XUtil, wins []xproto.Window) {
+	ewmh.ClientListStackingSet(x, wins)
+}

--- a/wm/property.go
+++ b/wm/property.go
@@ -159,10 +159,10 @@ func windowExtendedHintsRemove(x *xgbutil.XUtil, win xproto.Window, hint string)
 	}
 }
 
-func windowClientListSet(x *xgbutil.XUtil, wins []xproto.Window) {
-	ewmh.ClientListSet(x, wins)
+func windowClientListUpdate(wm *x11WM) {
+	ewmh.ClientListSet(wm.x, wm.getWindowsFromClients(wm.mappingOrder))
 }
 
-func windowClientListStackingSet(x *xgbutil.XUtil, wins []xproto.Window) {
-	ewmh.ClientListStackingSet(x, wins)
+func windowClientListStackingUpdate(wm *x11WM) {
+	ewmh.ClientListStackingSet(wm.x, wm.getWindowsFromClients(wm.clients))
 }

--- a/wm/screens.go
+++ b/wm/screens.go
@@ -85,7 +85,7 @@ func (x *x11WM) setupScreens() {
 					firstFoundMmWidth = outputInfo.MmWidth
 					firstFoundWidth = crtcInfo.Width
 				}
-				x.screens = append(x.screens, &desktop.Head{Name: string(outputInfo.Name),
+				x.screens = append(x.screens, &desktop.Screen{Name: string(outputInfo.Name),
 					X: int(crtcInfo.X), Y: int(crtcInfo.Y), Width: int(crtcInfo.Width), Height: int(crtcInfo.Height)})
 				if primaryInfo != nil {
 					if string(primaryInfo.Name) == string(outputInfo.Name) {
@@ -111,7 +111,7 @@ func (x *x11WM) setupScreens() {
 		}
 	}
 	if len(x.screens) == 0 {
-		x.screens = append(x.screens, &desktop.Head{Name: "Screen0",
+		x.screens = append(x.screens, &desktop.Screen{Name: "Screen0",
 			X: xwindow.RootGeometry(x.x).X(), Y: xwindow.RootGeometry(x.x).Y(),
 			Width: xwindow.RootGeometry(x.x).Width(), Height: xwindow.RootGeometry(x.x).Height(),
 			ScaledX: xwindow.RootGeometry(x.x).X(), ScaledY: xwindow.RootGeometry(x.x).Y(),

--- a/wm/screens.go
+++ b/wm/screens.go
@@ -85,7 +85,7 @@ func (x *x11WM) setupScreens() {
 					firstFoundMmWidth = outputInfo.MmWidth
 					firstFoundWidth = crtcInfo.Width
 				}
-				x.screens = append(x.screens, &desktop.Screen{Name: string(outputInfo.Name), Index: i,
+				x.screens = append(x.screens, &desktop.Head{Name: string(outputInfo.Name),
 					X: int(crtcInfo.X), Y: int(crtcInfo.Y), Width: int(crtcInfo.Width), Height: int(crtcInfo.Height)})
 				if primaryInfo != nil {
 					if string(primaryInfo.Name) == string(outputInfo.Name) {
@@ -102,16 +102,16 @@ func (x *x11WM) setupScreens() {
 				x.active = x.screens[0]
 				x.scale = getScale(firstFoundWidth, firstFoundMmWidth)
 			}
-			for _, screen := range x.screens {
-				screen.ScaledX = int(float32(screen.X) / x. scale)
-				screen.ScaledY = int(float32(screen.Y) / x.scale)
-				screen.ScaledWidth = int(float32(screen.Width) / x.scale)
-				screen.ScaledHeight = int(float32(screen.Height) / x.scale)
+			for _, head := range x.screens {
+				head.ScaledX = int(math.Round(float64(head.X) / float64(x.scale)))
+				head.ScaledY = int(math.Round(float64(head.Y) / float64(x.scale)))
+				head.ScaledWidth = int(math.Round(float64(head.Width) / float64(x.scale)))
+				head.ScaledHeight = int(math.Round(float64(head.Height) / float64(x.scale)))
 			}
 		}
 	}
 	if len(x.screens) == 0 {
-		x.screens = append(x.screens, &desktop.Screen{Name: "Screen0", Index: 0,
+		x.screens = append(x.screens, &desktop.Head{Name: "Screen0",
 			X: xwindow.RootGeometry(x.x).X(), Y: xwindow.RootGeometry(x.x).Y(),
 			Width: xwindow.RootGeometry(x.x).Width(), Height: xwindow.RootGeometry(x.x).Height(),
 			ScaledX: xwindow.RootGeometry(x.x).X(), ScaledY: xwindow.RootGeometry(x.x).Y(),

--- a/wm/screens.go
+++ b/wm/screens.go
@@ -1,0 +1,123 @@
+package wm
+
+import (
+	"math"
+	"os"
+	"strconv"
+
+	"fyne.io/desktop"
+	"fyne.io/fyne"
+	"github.com/BurntSushi/xgb/randr"
+	"github.com/BurntSushi/xgb/xproto"
+	"github.com/BurntSushi/xgbutil/xwindow"
+)
+
+func getScale(widthPx uint16, widthMm uint32) float32 {
+	env := os.Getenv("FYNE_SCALE")
+
+	if env != "" && env != "auto" {
+		scale, err := strconv.ParseFloat(env, 32)
+		if err == nil && scale != 0 {
+			return float32(scale)
+		}
+		fyne.LogError("Error reading scale", err)
+	}
+
+	if env != "auto" {
+		setting := fyne.CurrentApp().Settings().Scale()
+		switch setting {
+		case fyne.SettingsScaleAuto:
+			// fall through
+		case 0.0:
+			if env == "" {
+				return 1.0
+			}
+			// fall through
+		default:
+			return setting
+		}
+	}
+
+	dpi := float32(widthPx) / (float32(widthMm) / 25.4)
+	if dpi > 1000 || dpi < 10 {
+		dpi = 96
+	}
+	return float32(math.Round(float64(dpi)/144.0*10.0)) / 10.0
+}
+
+func (x *x11WM) setupScreens() {
+	err := randr.Init(x.x.Conn())
+	if err != nil {
+		fyne.LogError("Could not initialize randr", err)
+	} else {
+		root := xproto.Setup(x.x.Conn()).DefaultScreen(x.x.Conn()).Root
+		resources, err := randr.GetScreenResources(x.x.Conn(), root).Reply()
+		if err != nil {
+			fyne.LogError("Could not get randr screen resources", err)
+		} else {
+			primary, err := randr.GetOutputPrimary(x.x.Conn(),
+				xproto.Setup(x.x.Conn()).DefaultScreen(x.x.Conn()).Root).Reply()
+			if err != nil {
+				fyne.LogError("Could not determine randr primary output", err)
+			}
+			primaryInfo, err := randr.GetOutputInfo(x.x.Conn(), primary.Output, 0).Reply()
+			if err != nil {
+				fyne.LogError("Could not determine randr primary output information", err)
+			}
+			primaryFound := false
+			var scale float32 = 1.0
+			var firstFoundMmWidth uint32 = 0
+			var firstFoundWidth uint16 = 0
+			i := 0
+			for _, output := range resources.Outputs {
+				outputInfo, err := randr.GetOutputInfo(x.x.Conn(), output, 0).Reply()
+				if err != nil {
+					fyne.LogError("Could not get randr output", err)
+					continue
+				}
+				if outputInfo.Crtc == 0 || outputInfo.Connection == randr.ConnectionDisconnected {
+					continue
+				}
+				crtcInfo, err := randr.GetCrtcInfo(x.x.Conn(), outputInfo.Crtc, 0).Reply()
+				if err != nil {
+					fyne.LogError("Could not get randr crtcs", err)
+					continue
+				}
+				if i == 0 {
+					firstFoundMmWidth = outputInfo.MmWidth
+					firstFoundWidth = crtcInfo.Width
+				}
+				x.screens = append(x.screens, desktop.Screen{Name: string(outputInfo.Name), Index: i,
+					X: int(crtcInfo.X), Y: int(crtcInfo.Y), Width: int(crtcInfo.Width), Height: int(crtcInfo.Height)})
+				if primaryInfo != nil {
+					if string(primaryInfo.Name) == string(outputInfo.Name) {
+						primaryFound = true
+						x.primary = i
+						x.active = i
+						scale = getScale(crtcInfo.Width, outputInfo.MmWidth)
+					}
+				}
+				i++
+			}
+			if !primaryFound {
+				scale = getScale(firstFoundWidth, firstFoundMmWidth)
+			}
+			for j, screen := range x.screens {
+				screen.ScaledX = int(float32(screen.X) / scale)
+				screen.ScaledY = int(float32(screen.Y) / scale)
+				screen.ScaledWidth = int(float32(screen.Width) / scale)
+				screen.ScaledHeight = int(float32(screen.Height) / scale)
+				x.screens[j] = screen
+			}
+		}
+	}
+	if len(x.screens) == 0 {
+		x.screens = append(x.screens, desktop.Screen{Name: "Screen0", Index: 0,
+			X: xwindow.RootGeometry(x.x).X(), Y: xwindow.RootGeometry(x.x).Y(),
+			Width: xwindow.RootGeometry(x.x).Width(), Height: xwindow.RootGeometry(x.x).Height(),
+			ScaledX: xwindow.RootGeometry(x.x).X(), ScaledY: xwindow.RootGeometry(x.x).Y(),
+			ScaledWidth: xwindow.RootGeometry(x.x).Width(), ScaledHeight: xwindow.RootGeometry(x.x).Height()})
+		x.primary = 0
+		x.active = 0
+	}
+}

--- a/wm/screens.go
+++ b/wm/screens.go
@@ -153,20 +153,12 @@ func (xsp *x11ScreensProvider) setupScreens(x *x11WM) {
 				xsp.active = xsp.screens[0]
 				xsp.scale = getScale(firstFoundWidth, firstFoundMmWidth)
 			}
-			for _, head := range xsp.screens {
-				head.ScaledX = int(math.Round(float64(head.X) / float64(xsp.scale)))
-				head.ScaledY = int(math.Round(float64(head.Y) / float64(xsp.scale)))
-				head.ScaledWidth = int(math.Round(float64(head.Width) / float64(xsp.scale)))
-				head.ScaledHeight = int(math.Round(float64(head.Height) / float64(xsp.scale)))
-			}
 		}
 	}
 	if len(xsp.screens) == 0 {
 		xsp.screens = append(xsp.screens, &desktop.Screen{Name: "Screen0",
 			X: xwindow.RootGeometry(x.x).X(), Y: xwindow.RootGeometry(x.x).Y(),
-			Width: xwindow.RootGeometry(x.x).Width(), Height: xwindow.RootGeometry(x.x).Height(),
-			ScaledX: xwindow.RootGeometry(x.x).X(), ScaledY: xwindow.RootGeometry(x.x).Y(),
-			ScaledWidth: xwindow.RootGeometry(x.x).Width(), ScaledHeight: xwindow.RootGeometry(x.x).Height()})
+			Width: xwindow.RootGeometry(x.x).Width(), Height: xwindow.RootGeometry(x.x).Height()})
 		xsp.primary = xsp.screens[0]
 		xsp.active = xsp.screens[0]
 	}

--- a/wm/stack.go
+++ b/wm/stack.go
@@ -2,7 +2,6 @@ package wm
 
 import (
 	"fyne.io/desktop"
-	"github.com/BurntSushi/xgb/xproto"
 )
 
 type stack struct {
@@ -47,16 +46,12 @@ func (s *stack) removeFromStack(win desktop.Window) {
 	s.mappingOrder = append(s.mappingOrder[:pos], s.mappingOrder[pos+1:]...)
 }
 
-func (s *stack) getMappingOrder() []xproto.Window {
-	return s.getWindowsFromClients(s.mappingOrder)
+func (s *stack) getMappingOrder() []desktop.Window {
+	return s.mappingOrder
 }
 
-func (s *stack) getWindowsFromClients(clients []desktop.Window) []xproto.Window {
-	var wins []xproto.Window
-	for _, cli := range clients {
-		wins = append(wins, cli.(*client).id)
-	}
-	return wins
+func (s *stack) getClients(clients []desktop.Window) []desktop.Window {
+	return s.clients
 }
 
 func (s *stack) AddWindow(win desktop.Window) {


### PR DESCRIPTION
This supports configurable primary screens, user defined scaling, auto scaling, and fixes a lot of issues with apps such as gnome apps.

The one caveat here is that there is one scale value across all monitors, rather than being calculated per monitor.  This will need to be addressed in the future.

Fixes #27