### PR TITLE
Transient fix, lint fix, and configure notify fix

### DIFF
--- a/internal/notify/mouse.go
+++ b/internal/notify/mouse.go
@@ -2,7 +2,7 @@ package notify
 
 import "fyne.io/fyne"
 
-// MouseNotify is an interface that lets separate packages like wm tell the desktop that the cursor has moved to or from the desktop canvas.
+// MouseNotify is an interface that can be used by objects interested in when the mouse enters or exits the desktop
 type MouseNotify interface {
 	MouseInNotify(fyne.Position)
 	MouseOutNotify()

--- a/internal/notify/mouse.go
+++ b/internal/notify/mouse.go
@@ -2,6 +2,7 @@ package notify
 
 import "fyne.io/fyne"
 
+// MouseNotify is an interface that lets separate packages like wm tell the desktop that the cursor has moved to or from the desktop canvas.
 type MouseNotify interface {
 	MouseInNotify(fyne.Position)
 	MouseOutNotify()

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -168,6 +168,10 @@ func (x *x11WM) runLoop() {
 		}
 		switch ev := ev.(type) {
 		case xproto.MapRequestEvent:
+			override := windowOverrideGet(x.x, ev.Window)
+			if override == true {
+				return
+			}
 			x.showWindow(ev.Window)
 		case xproto.UnmapNotifyEvent:
 			x.hideWindow(ev.Window)

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -168,10 +168,6 @@ func (x *x11WM) runLoop() {
 		}
 		switch ev := ev.(type) {
 		case xproto.MapRequestEvent:
-			override := windowOverrideGet(x.x, ev.Window)
-			if override == true {
-				return
-			}
 			x.showWindow(ev.Window)
 		case xproto.UnmapNotifyEvent:
 			x.hideWindow(ev.Window)

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -209,16 +209,16 @@ func (x *x11WM) runLoop() {
 				if c.(*client).id == ev.Event {
 					if x.moveResizing {
 						x.moveResizeEnd()
-						// ensure menus etc update
-						f := c.(*client).frame
-						innerX, innerY, innerW, innerH := f.getInnerWindowCoordinates(f.x, f.y, f.width, f.height)
-						ev := xproto.ConfigureNotifyEvent{Event: f.client.win, Window: f.client.win, AboveSibling: 0,
-							X: int16(f.x + int16(innerX)), Y: int16(f.y + int16(innerY)), Width: uint16(innerW), Height: uint16(innerH),
-							BorderWidth: f.borderWidth(), OverrideRedirect: false}
-						xproto.SendEvent(f.client.wm.x.Conn(), false, f.client.win, xproto.EventMaskStructureNotify, string(ev.Bytes()))
-						break
+					} else {
+						c.(*client).frame.release(ev.RootX, ev.RootY)
 					}
-					c.(*client).frame.release(ev.RootX, ev.RootY)
+					// ensure menus etc update
+					f := c.(*client).frame
+					innerX, innerY, innerW, innerH := f.getInnerWindowCoordinates(f.x, f.y, f.width, f.height)
+					ev := xproto.ConfigureNotifyEvent{Event: f.client.win, Window: f.client.win, AboveSibling: 0,
+						X: int16(f.x + int16(innerX)), Y: int16(f.y + int16(innerY)), Width: uint16(innerW), Height: uint16(innerH),
+						BorderWidth: f.borderWidth(), OverrideRedirect: false}
+					xproto.SendEvent(f.client.wm.x.Conn(), false, f.client.win, xproto.EventMaskStructureNotify, string(ev.Bytes()))
 				}
 			}
 		case xproto.MotionNotifyEvent:

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -209,6 +209,13 @@ func (x *x11WM) runLoop() {
 				if c.(*client).id == ev.Event {
 					if x.moveResizing {
 						x.moveResizeEnd()
+						// ensure menus etc update
+						f := c.(*client).frame
+						innerX, innerY, innerW, innerH := f.getInnerWindowCoordinates(f.x, f.y, f.width, f.height)
+						ev := xproto.ConfigureNotifyEvent{Event: f.client.win, Window: f.client.win, AboveSibling: 0,
+							X: int16(f.x + int16(innerX)), Y: int16(f.y + int16(innerY)), Width: uint16(innerW), Height: uint16(innerH),
+							BorderWidth: f.borderWidth(), OverrideRedirect: false}
+						xproto.SendEvent(f.client.wm.x.Conn(), false, f.client.win, xproto.EventMaskStructureNotify, string(ev.Bytes()))
 						break
 					}
 					c.(*client).frame.release(ev.RootX, ev.RootY)

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -541,15 +541,13 @@ func (x *x11WM) showWindow(win xproto.Window) {
 	if override {
 		return
 	}
-	transient := windowTransientForGet(x.x, win)
-	if transient != 0 {
-		winType := windowTypeGet(x.x, win)
-		switch winType[0] {
-		case windowTypeUtility, windowTypeDialog, windowTypeNormal:
-			break
-		default:
-			return
-		}
+
+	winType := windowTypeGet(x.x, win)
+	switch winType[0] {
+	case windowTypeUtility, windowTypeDialog, windowTypeNormal:
+		break
+	default:
+		return
 	}
 
 	x.setupWindow(win)

--- a/wm/frame.go
+++ b/wm/frame.go
@@ -105,13 +105,6 @@ func (f *frame) release(x, y int16) {
 	f.resizeLeft = false
 	f.resizeRight = false
 	f.updateGeometry(f.x, f.y, f.width, f.height, false)
-
-	// ensure menus etc update
-	innerX, innerY, innerW, innerH := f.getInnerWindowCoordinates(f.x, f.y, f.width, f.height)
-	ev := xproto.ConfigureNotifyEvent{Event: f.client.win, Window: f.client.win, AboveSibling: 0,
-		X: int16(f.x + int16(innerX)), Y: int16(f.y + int16(innerY)), Width: uint16(innerW), Height: uint16(innerH),
-		BorderWidth: f.borderWidth(), OverrideRedirect: false}
-	xproto.SendEvent(f.client.wm.x.Conn(), false, f.client.win, xproto.EventMaskStructureNotify, string(ev.Bytes()))
 }
 
 func (f *frame) drag(x, y int16) {

--- a/wm/property.go
+++ b/wm/property.go
@@ -170,9 +170,11 @@ func windowTransientForGet(x *xgbutil.XUtil, win xproto.Window) xproto.Window {
 
 func windowOverrideGet(x *xgbutil.XUtil, win xproto.Window) bool {
 	hints, err := icccm.WmHintsGet(x, win)
-	if err != nil {
-		return false
-	} else if (hints.Flags & xproto.CwOverrideRedirect) != 0 {
+	if err == nil && (hints.Flags&xproto.CwOverrideRedirect) != 0 {
+		return true
+	}
+	attrs, err := xproto.GetWindowAttributes(x.Conn(), win).Reply()
+	if err == nil && attrs.OverrideRedirect {
 		return true
 	}
 	return false


### PR DESCRIPTION
A few bug fixes for release -

We only want to manage certain windows regardless of whether have the transient property, so the transient check was useless and actually messed up a few menus that didn't have transient set but had window type menu set.

Fix lint warning on MouseNotify interface.

Borderless windows need the synthetic configure notify as well decorated ones.  Refactoring out the synthetic notify to be in the release function of frame broke borderless windows getting updated correctly.  This fixes that.