### PR TITLE
Add key bindings for app launcher

### DIFF
--- a/internal/ui/desk_test.go
+++ b/internal/ui/desk_test.go
@@ -4,15 +4,17 @@ import (
 	"image/color"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"fyne.io/fyne/test"
 	"github.com/stretchr/testify/assert"
 
-	"fyne.io/desktop"
-	wmTheme "fyne.io/desktop/theme"
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+
+	"fyne.io/desktop"
+	wmTheme "fyne.io/desktop/theme"
 )
 
 type testDesk struct {
@@ -153,10 +155,11 @@ func (tad *testAppData) Icon(theme string, size int) fyne.Resource {
 
 type testAppProvider struct {
 	screens []*desktop.Screen
+	apps    []desktop.AppData
 }
 
 func (tap *testAppProvider) AvailableApps() []desktop.AppData {
-	return nil
+	return tap.apps
 }
 
 func (tap *testAppProvider) AvailableThemes() []string {
@@ -172,11 +175,30 @@ func (tap *testAppProvider) FindAppFromWinInfo(win desktop.Window) desktop.AppDa
 }
 
 func (tap *testAppProvider) FindAppsMatching(pattern string) []desktop.AppData {
-	return nil
+	var ret []desktop.AppData
+	for _, app := range tap.apps {
+		if !strings.Contains(strings.ToLower(app.Name()), strings.ToLower(pattern)) {
+			continue
+		}
+
+		ret = append(ret, app)
+	}
+
+	return ret
 }
 
 func (tap *testAppProvider) DefaultApps() []desktop.AppData {
 	return nil
+}
+
+func newTestAppProvider(appNames []string) *testAppProvider {
+	provider := &testAppProvider{}
+
+	for _, name := range appNames {
+		provider.apps = append(provider.apps, &testAppData{name: name})
+	}
+
+	return provider
 }
 
 func TestDeskLayout_Layout(t *testing.T) {

--- a/internal/ui/launcher.go
+++ b/internal/ui/launcher.go
@@ -30,8 +30,10 @@ func (e *appEntry) TypedKey(ev *fyne.KeyEvent) {
 }
 
 type launcher struct {
-	win     fyne.Window
-	desk    desktop.Desktop
+	win  fyne.Window
+	desk desktop.Desktop
+
+	entry   *appEntry
 	appList *fyne.Container
 }
 
@@ -57,7 +59,12 @@ func (l *launcher) runApp(app desktop.AppData) {
 }
 
 func (l *launcher) updateAppListMatching(input string) {
-	l.appList.Objects = []fyne.CanvasObject{}
+	l.appList.Objects = l.appButtonListMatching(input)
+	l.appList.Refresh()
+}
+
+func (l *launcher) appButtonListMatching(input string) []fyne.CanvasObject {
+	var appList []fyne.CanvasObject
 
 	iconTheme := l.desk.Settings().IconTheme()
 	dataRange := l.desk.IconProvider().FindAppsMatching(input)
@@ -71,8 +78,10 @@ func (l *launcher) updateAppListMatching(input string) {
 		if i == 0 {
 			app.Style = widget.PrimaryButton
 		}
-		l.appList.AddObject(app)
+		appList = append(appList, app)
 	}
+
+	return appList
 }
 
 func newAppLauncher(desk desktop.Desktop) *launcher {
@@ -98,6 +107,7 @@ func newAppLauncher(desk desktop.Desktop) *launcher {
 
 		l.updateAppListMatching(input)
 	}
+	l.entry = entry
 
 	cancel := widget.NewButtonWithIcon("Cancel", theme.CancelIcon(), func() {
 		win.Close()

--- a/internal/ui/launcher.go
+++ b/internal/ui/launcher.go
@@ -18,23 +18,27 @@ type appEntry struct {
 }
 
 func (e *appEntry) TypedKey(ev *fyne.KeyEvent) {
-	if ev.Name == fyne.KeyEscape {
+	switch ev.Name {
+	case fyne.KeyEscape:
 		e.launch.close()
-		return
-	} else if ev.Name == fyne.KeyReturn {
+	case fyne.KeyReturn:
 		e.launch.runSelected()
-		return
+	case fyne.KeyUp:
+		e.launch.setActiveIndex(e.launch.activeIndex - 1)
+	case fyne.KeyDown:
+		e.launch.setActiveIndex(e.launch.activeIndex + 1)
+	default:
+		e.Entry.TypedKey(ev)
 	}
-
-	e.Entry.TypedKey(ev)
 }
 
 type launcher struct {
 	win  fyne.Window
 	desk desktop.Desktop
 
-	entry   *appEntry
-	appList *fyne.Container
+	entry       *appEntry
+	appList     *fyne.Container
+	activeIndex int
 }
 
 func (l *launcher) close() {
@@ -46,7 +50,18 @@ func (l *launcher) runSelected() {
 		return
 	}
 
-	l.appList.Objects[0].(*widget.Button).OnTapped()
+	l.appList.Objects[l.activeIndex].(*widget.Button).OnTapped()
+}
+
+func (l *launcher) setActiveIndex(index int) {
+	if index < 0 || index >= len(l.appList.Objects) {
+		return
+	}
+
+	l.appList.Objects[l.activeIndex].(*widget.Button).Style = widget.DefaultButton
+	l.appList.Objects[index].(*widget.Button).Style = widget.PrimaryButton
+	l.activeIndex = index
+	l.appList.Refresh()
 }
 
 func (l *launcher) runApp(app desktop.AppData) {
@@ -59,6 +74,7 @@ func (l *launcher) runApp(app desktop.AppData) {
 }
 
 func (l *launcher) updateAppListMatching(input string) {
+	l.activeIndex = 0
 	l.appList.Objects = l.appButtonListMatching(input)
 	l.appList.Refresh()
 }

--- a/internal/ui/launcher_test.go
+++ b/internal/ui/launcher_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"testing"
 
+	"fyne.io/fyne"
 	"fyne.io/fyne/test"
 	"fyne.io/fyne/widget"
 	"github.com/stretchr/testify/assert"
@@ -36,4 +37,18 @@ func TestLauncher_ListTyped(t *testing.T) {
 	assert.Equal(t, 2, len(launcher.appList.Objects))
 	test.Type(launcher.entry, "Appy")
 	assert.Equal(t, 0, len(launcher.appList.Objects))
+}
+
+func TestLauncher_ListActive(t *testing.T) {
+	names := []string{"App 1", "App 2", "Another"}
+	desk := &testDesk{icons: newTestAppProvider(names), settings: &testSettings{}}
+	launcher := newAppLauncher(desk)
+
+	assert.Equal(t, 0, len(launcher.appList.Objects))
+	assert.Equal(t, 0, launcher.activeIndex)
+	test.Type(launcher.entry, "App")
+	launcher.entry.TypedKey(&fyne.KeyEvent{Name: fyne.KeyDown})
+	assert.Equal(t, 1, launcher.activeIndex)
+	assert.Equal(t, widget.DefaultButton, launcher.appList.Objects[0].(*widget.Button).Style)
+	assert.Equal(t, widget.PrimaryButton, launcher.appList.Objects[1].(*widget.Button).Style)
 }

--- a/internal/ui/launcher_test.go
+++ b/internal/ui/launcher_test.go
@@ -1,0 +1,39 @@
+package ui
+
+import (
+	"testing"
+
+	"fyne.io/fyne/test"
+	"fyne.io/fyne/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLauncher_ListMatches(t *testing.T) {
+	names := []string{"App 1", "App 2", "Another"}
+	desk := &testDesk{icons: newTestAppProvider(names), settings: &testSettings{}}
+	launcher := newAppLauncher(desk)
+
+	apps := launcher.appButtonListMatching("App")
+	assert.Equal(t, 2, len(apps))
+	assert.Equal(t, "App 1", apps[0].(*widget.Button).Text)
+	assert.Equal(t, "App 2", apps[1].(*widget.Button).Text)
+
+	apps = launcher.appButtonListMatching("ano")
+	assert.Equal(t, 1, len(apps))
+	assert.Equal(t, "Another", apps[0].(*widget.Button).Text)
+
+	apps = launcher.appButtonListMatching("miss")
+	assert.Equal(t, 0, len(apps))
+}
+
+func TestLauncher_ListTyped(t *testing.T) {
+	names := []string{"App 1", "App 2", "Another"}
+	desk := &testDesk{icons: newTestAppProvider(names), settings: &testSettings{}}
+	launcher := newAppLauncher(desk)
+
+	assert.Equal(t, 0, len(launcher.appList.Objects))
+	test.Type(launcher.entry, "App")
+	assert.Equal(t, 2, len(launcher.appList.Objects))
+	test.Type(launcher.entry, "Appy")
+	assert.Equal(t, 0, len(launcher.appList.Objects))
+}

--- a/internal/ui/launcher_test.go
+++ b/internal/ui/launcher_test.go
@@ -52,3 +52,21 @@ func TestLauncher_ListActive(t *testing.T) {
 	assert.Equal(t, widget.DefaultButton, launcher.appList.Objects[0].(*widget.Button).Style)
 	assert.Equal(t, widget.PrimaryButton, launcher.appList.Objects[1].(*widget.Button).Style)
 }
+
+func TestLauncher_setActiveIndex(t *testing.T) {
+	names := []string{"App 1", "App 2", "Another"}
+	desk := &testDesk{icons: newTestAppProvider(names), settings: &testSettings{}}
+	launcher := newAppLauncher(desk)
+
+	launcher.appList.Objects = launcher.appButtonListMatching("App")
+	assert.Equal(t, 0, launcher.activeIndex)
+
+	launcher.setActiveIndex(1)
+	assert.Equal(t, 1, launcher.activeIndex)
+
+	launcher.setActiveIndex(2)
+	assert.Equal(t, 1, launcher.activeIndex)
+
+	launcher.setActiveIndex(-1)
+	assert.Equal(t, 1, launcher.activeIndex)
+}

--- a/internal/ui/widgetpanel.go
+++ b/internal/ui/widgetpanel.go
@@ -220,17 +220,7 @@ func (w *widgetPanel) CreateRenderer() fyne.WidgetRenderer {
 	account = widget.NewButtonWithIcon(accountLabel, wmtheme.UserIcon, func() {
 		w.showAccountMenu(account)
 	})
-	appExecButton := widget.NewButtonWithIcon("Applications", theme.SearchIcon(), func() {
-		if w.appExecWin != nil {
-			w.appExecWin.Close()
-		}
-
-		w.appExecWin = newAppExecPopUp(w.desk)
-		w.appExecWin.SetOnClosed(func() {
-			w.appExecWin = nil
-		})
-		w.appExecWin.Show()
-	})
+	appExecButton := widget.NewButtonWithIcon("Applications", theme.SearchIcon(), ShowAppLauncher)
 	objects := []fyne.CanvasObject{
 		w.clock,
 		w.date,

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -17,6 +17,8 @@ import (
 
 	"fyne.io/desktop"
 	"fyne.io/desktop/internal/notify"
+	"fyne.io/desktop/internal/ui"
+
 	"fyne.io/fyne"
 )
 
@@ -53,8 +55,9 @@ const (
 	moveResizeMoveKeyboard moveResizeType = 10
 	moveResizeCancel       moveResizeType = 11
 
-	keyCodeTab = 23
-	keyCodeAlt = 64
+	keyCodeTab   = 23
+	keyCodeAlt   = 64
+	keyCodeSpace = 65
 )
 
 func (x *x11WM) Close() {
@@ -251,6 +254,12 @@ func (x *x11WM) runLoop() {
 					int(float32(ev.RootY)/x.root.Canvas().Scale())))
 			}
 		case xproto.KeyPressEvent:
+			if ev.Detail == keyCodeSpace {
+				go ui.ShowAppLauncher()
+				break
+			} else if ev.Detail != keyCodeTab {
+				break
+			}
 			if x.altTabList == nil {
 				x.altTabList = []desktop.Window{}
 				for _, win := range x.Windows() {
@@ -264,9 +273,6 @@ func (x *x11WM) runLoop() {
 				xproto.GrabKeyboard(x.x.Conn(), true, x.rootID, xproto.TimeCurrentTime, xproto.GrabModeAsync, xproto.GrabModeAsync)
 			}
 
-			if ev.Detail != keyCodeTab {
-				break
-			}
 			winCount := len(x.altTabList)
 			if winCount <= 1 {
 				break
@@ -601,6 +607,7 @@ func (x *x11WM) destroyWindow(win xproto.Window) {
 }
 
 func (x *x11WM) bindKeys(win xproto.Window) {
+	xproto.GrabKey(x.x.Conn(), true, win, xproto.ModMask1, keyCodeSpace, xproto.GrabModeAsync, xproto.GrabModeAsync)
 	xproto.GrabKey(x.x.Conn(), true, win, xproto.ModMask1, keyCodeTab, xproto.GrabModeAsync, xproto.GrabModeAsync)
 	xproto.GrabKey(x.x.Conn(), true, win, xproto.ModMaskShift|xproto.ModMask1, keyCodeTab, xproto.GrabModeAsync, xproto.GrabModeAsync)
 }


### PR DESCRIPTION
This adds a "selected app" in the list as well as the keyboard bindings:
* Alt-space to open launcher
* Escape to close it
* Enter will launch the selected app
* Up and down will change the app selected

Also new tests are added which is easier with the refactored code.