### PR TITLE
Feature/app switcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module fyne.io/desktop
 go 1.12
 
 require (
-	fyne.io/fyne v1.2.2-0.20191224225653-64936716f619
+	fyne.io/fyne v1.2.2-0.20200129164526-631a82cd1cae
 	github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298 // indirect
 	github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-fyne.io/fyne v1.2.2-0.20191224225653-64936716f619 h1:JRhZpnKIKhkIB/ZqkvfehomyK3yHNIoIn/a2l9Dtg1w=
-fyne.io/fyne v1.2.2-0.20191224225653-64936716f619/go.mod h1:AwxWB9CEwG1B7XFmnj5zRW5jEI5aiyeXYe4Ve83L96c=
+fyne.io/fyne v1.2.2-0.20200129164526-631a82cd1cae h1:rKZISt/yDJqh9Lp9IgiHWgtMCqvnBTj2miLtuyon93c=
+fyne.io/fyne v1.2.2-0.20200129164526-631a82cd1cae/go.mod h1:AwxWB9CEwG1B7XFmnj5zRW5jEI5aiyeXYe4Ve83L96c=
 github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298 h1:1qlsVAQJXZHsaM8b6OLVo6muQUQd4CwkH/D3fnnbHXA=
 github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298/go.mod h1:D+QujdIlUNfa0igpNMk6UIvlb6C252URs4yupRUV4lQ=
 github.com/BurntSushi/graphics-go v0.0.0-20160129215708-b43f31a4a966 h1:lTG4HQym5oPKjL7nGs+csTgiDna685ZXjxijkne828g=

--- a/internal/ui/bar_test.go
+++ b/internal/ui/bar_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"fyne.io/fyne"
@@ -14,94 +15,100 @@ import (
 )
 
 type dummyWindow struct {
+	name   string // a name to override the dummy default
+	raised bool   // this flag shows we were requested to raise above the other windows
 }
 
-func (*dummyWindow) Decorated() bool {
+func (w *dummyWindow) Decorated() bool {
 	return true
 }
 
-func (*dummyWindow) Title() string {
-	return "Xterm"
+func (w *dummyWindow) Title() string {
+	if w.name == "" {
+		return "Xterm"
+	}
+
+	return w.name
 }
 
-func (*dummyWindow) Class() []string {
-	return []string{"Xterm", "xterm"}
+func (w *dummyWindow) Class() []string {
+	return []string{w.Title(), "xterm"}
 }
 
-func (*dummyWindow) Command() string {
-	return "xterm"
+func (w *dummyWindow) Command() string {
+	return strings.ToLower(w.Title())
 }
 
-func (*dummyWindow) IconName() string {
-	return "xterm"
+func (w *dummyWindow) IconName() string {
+	return strings.ToLower(w.Title())
 }
 
-func (*dummyWindow) Icon() fyne.Resource {
+func (w *dummyWindow) Icon() fyne.Resource {
 	return nil
 }
 
-func (*dummyWindow) Fullscreened() bool {
+func (w *dummyWindow) Fullscreened() bool {
 	return false
 }
 
-func (*dummyWindow) Iconic() bool {
+func (w *dummyWindow) Iconic() bool {
 	return false
 }
 
-func (*dummyWindow) Maximized() bool {
+func (w *dummyWindow) Maximized() bool {
 	return false
 }
 
-func (*dummyWindow) TopWindow() bool {
+func (w *dummyWindow) TopWindow() bool {
 	return true
 }
 
-func (*dummyWindow) SkipTaskbar() bool {
+func (w *dummyWindow) SkipTaskbar() bool {
 	return false
 }
 
-func (*dummyWindow) Focused() bool {
+func (w *dummyWindow) Focused() bool {
 	return false
 }
 
-func (*dummyWindow) Focus() {
+func (w *dummyWindow) Focus() {
 	// no-op
 }
 
-func (*dummyWindow) Close() {
+func (w *dummyWindow) Close() {
 	// no-op
 }
 
-func (*dummyWindow) Fullscreen() {
+func (w *dummyWindow) Fullscreen() {
 	// no-op
 }
 
-func (*dummyWindow) Unfullscreen() {
+func (w *dummyWindow) Unfullscreen() {
 	// no-op
 }
 
-func (*dummyWindow) Iconify() {
+func (w *dummyWindow) Iconify() {
 	// no-op
 }
 
-func (*dummyWindow) Uniconify() {
+func (w *dummyWindow) Uniconify() {
 	// no-op
 }
 
-func (*dummyWindow) Maximize() {
+func (w *dummyWindow) Maximize() {
 	// no-op
 }
 
-func (*dummyWindow) Unmaximize() {
+func (w *dummyWindow) Unmaximize() {
 	// no-op
 }
 
-func (*dummyWindow) RaiseAbove(desktop.Window) {
+func (w *dummyWindow) RaiseAbove(desktop.Window) {
 	// no-op (this is instructing the window after stack changes)
 }
 
-func (*dummyWindow) RaiseToTop() {
-	// no-op
+func (w *dummyWindow) RaiseToTop() {
+	w.raised = true
 }
 
 type dummyIcon struct {

--- a/internal/ui/switcher.go
+++ b/internal/ui/switcher.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"image/color"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+
+	"fyne.io/desktop"
+)
+
+var switcherInstance *switcher
+
+const (
+	switcherIconSize = 64
+	switcherTextSize = 24
+)
+
+type switchIcon struct {
+	widget.BaseWidget
+	current bool
+
+	parent *switcher
+	win    desktop.Window
+}
+
+func (s *switchIcon) CreateRenderer() fyne.WidgetRenderer {
+	var res fyne.Resource
+	title := s.win.Title()
+	app := desktop.Instance().IconProvider().FindAppFromWinInfo(s.win)
+	if app != nil {
+		res = app.Icon(desktop.Instance().Settings().IconTheme(), switcherIconSize*2)
+		title = app.Name()
+	} else {
+		res = s.win.Icon()
+	}
+
+	img := canvas.NewImageFromResource(res)
+	text := widget.NewLabel(title)
+	return &switchIconRenderer{icon: s,
+		img: img, text: text, objects: []fyne.CanvasObject{img, text}}
+}
+
+func (s *switchIcon) FocusGained() {
+	s.current = true
+	s.Refresh()
+}
+
+func (s *switchIcon) FocusLost() {
+	s.current = false
+	s.Refresh()
+}
+
+func (s *switchIcon) Focused() bool {
+	return s.current
+}
+
+func (s *switchIcon) TypedRune(rune) {
+}
+
+func (s *switchIcon) TypedKey(ev *fyne.KeyEvent) {
+	switch ev.Name {
+	case fyne.KeyReturn, fyne.KeyEnter:
+		s.parent.win.Close()
+
+		s.parent.raise(s)
+	case fyne.KeyRight:
+		s.parent.next()
+	case fyne.KeyLeft:
+		s.parent.previous()
+	case fyne.KeyEscape:
+		s.parent.win.Close()
+	}
+}
+func newSwitchIcon(p *switcher, win desktop.Window) *switchIcon {
+	ret := &switchIcon{
+		parent: p,
+		win:    win,
+	}
+	ret.ExtendBaseWidget(ret)
+	return ret
+}
+
+type switchIconRenderer struct {
+	icon *switchIcon
+
+	img     *canvas.Image
+	text    *widget.Label
+	objects []fyne.CanvasObject
+}
+
+func (s switchIconRenderer) Layout(fyne.Size) {
+	s.img.Resize(fyne.NewSize(switcherIconSize, switcherIconSize))
+	s.text.Resize(fyne.NewSize(switcherIconSize, switcherTextSize))
+	s.text.Move(fyne.NewPos(0, switcherIconSize+theme.Padding()))
+}
+
+func (s switchIconRenderer) MinSize() fyne.Size {
+	return fyne.NewSize(switcherIconSize, switcherIconSize+switcherTextSize+theme.Padding())
+}
+
+func (s switchIconRenderer) Refresh() {
+	canvas.Refresh(s.icon)
+}
+
+func (s switchIconRenderer) BackgroundColor() color.Color {
+	if s.icon.current {
+		return theme.PrimaryColor()
+	}
+	return theme.BackgroundColor()
+}
+
+func (s switchIconRenderer) Objects() []fyne.CanvasObject {
+	return s.objects
+}
+
+func (s switchIconRenderer) Destroy() {
+}
+
+type switcher struct {
+	win   fyne.Window
+	icons []fyne.CanvasObject
+}
+
+func (s *switcher) currentIndex() int {
+	for i, item := range s.icons {
+		if item.(*switchIcon).current {
+			return i
+		}
+	}
+
+	return 0
+}
+
+func (s *switcher) next() {
+	if len(s.icons) == 0 {
+		return
+	}
+
+	i := s.currentIndex()
+	i++
+	if i >= len(s.icons) {
+		i = 0
+	}
+	s.win.Canvas().Focus(s.icons[i].(*switchIcon))
+}
+
+func (s *switcher) previous() {
+	if len(s.icons) == 0 {
+		return
+	}
+
+	i := s.currentIndex()
+	i--
+	if i < 0 {
+		i = len(s.icons) - 1
+	}
+	s.win.Canvas().Focus(s.icons[i].(*switchIcon))
+}
+
+func (s *switcher) raise(icon *switchIcon) {
+	if icon.win.Iconic() {
+		icon.win.Uniconify()
+	}
+	icon.win.RaiseToTop()
+}
+
+func (s *switcher) loadUI() fyne.Window {
+	win := fyne.CurrentApp().NewWindow("Application instance")
+
+	win.SetContent(widget.NewHBox(s.icons...))
+	win.CenterOnScreen()
+
+	return win
+}
+
+func (s *switcher) loadIcons(list []desktop.Window) []fyne.CanvasObject {
+	var ret []fyne.CanvasObject
+
+	for _, item := range list {
+		ret = append(ret, newSwitchIcon(s, item))
+	}
+
+	return ret
+}
+
+func showAppSwitcherAt(off int, wm desktop.WindowManager) {
+	if wm == nil || len(wm.Windows()) <= 1 {
+		return
+	}
+	s := &switcher{}
+	s.icons = s.loadIcons(wm.Windows())
+	s.win = s.loadUI()
+	if off < 0 {
+		off = len(s.icons) + off // plus a negative is minus
+	}
+	s.win.Canvas().Focus(s.icons[off].(*switchIcon))
+	s.win.SetOnClosed(func() {
+		switcherInstance = nil
+	})
+	s.win.Show()
+	switcherInstance = s
+}
+
+// ShowAppSwitcher shows the application switcher to change windows.
+// The most recently used not-top window will be selected by default.
+// If the switcher was already visible then it will select the next window in order.
+func ShowAppSwitcher() {
+	wm := desktop.Instance().WindowManager()
+	if switcherInstance != nil {
+		switcherInstance.next()
+		return
+	}
+
+	showAppSwitcherAt(1, wm)
+}
+
+// ShowAppSwitcherReverse shows the application switcher to change windows.
+// The least recently used window will be selected by default.
+// If the switcher was already visible then it will select the last window in order.
+func ShowAppSwitcherReverse() {
+	wm := desktop.Instance().WindowManager()
+	if switcherInstance != nil {
+		switcherInstance.previous()
+		return
+	}
+
+	showAppSwitcherAt(-1, wm)
+}
+
+// HideAppSwitcher dismisses the application switcher and raises
+// whichever window was selected.
+func HideAppSwitcher() {
+	if switcherInstance == nil {
+		return
+	}
+
+	switcherInstance.win.Close()
+	switcherInstance.raise(switcherInstance.win.Canvas().Focused().(*switchIcon))
+}

--- a/internal/ui/switcher.go
+++ b/internal/ui/switcher.go
@@ -5,6 +5,7 @@ import (
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
+	deskDriver "fyne.io/fyne/driver/desktop"
 	"fyne.io/fyne/theme"
 	"fyne.io/fyne/widget"
 
@@ -172,7 +173,13 @@ func (s *Switcher) raise(icon *switchIcon) {
 }
 
 func (s *Switcher) loadUI() fyne.Window {
-	win := fyne.CurrentApp().NewWindow("Application instance")
+	var win fyne.Window
+	if d, ok := fyne.CurrentApp().Driver().(deskDriver.Driver); ok {
+		win = d.CreateSplashWindow()
+		win.SetPadded(true)
+	} else {
+		win = fyne.CurrentApp().NewWindow("Application instance")
+	}
 
 	win.SetContent(widget.NewHBox(s.icons...))
 	win.CenterOnScreen()

--- a/internal/ui/switcher_test.go
+++ b/internal/ui/switcher_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fyne.io/desktop"
+)
+
+func testWindows() []desktop.Window {
+	desk := &deskLayout{}
+	desk.settings = &testSettings{}
+	desktop.SetInstance(desk)
+	return []desktop.Window{
+		&dummyWindow{name: "App1"},
+		&dummyWindow{name: "App2"},
+		&dummyWindow{name: "App3"},
+	}
+}
+
+func TestShowAppSwitcher(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcher(wins, &testAppProvider{})
+
+	assert.NotNil(t, s.win)
+	assert.Equal(t, 1, s.currentIndex())
+}
+
+func TestShowAppSwitcherReverse(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcherReverse(wins, &testAppProvider{})
+
+	assert.NotNil(t, s.win)
+	assert.Equal(t, len(wins)-1, s.currentIndex())
+}
+
+func TestSwitcher_Next(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcher(wins, &testAppProvider{})
+
+	current := s.currentIndex()
+	s.Next()
+	assert.Equal(t, current+1, s.currentIndex())
+
+	s.setCurrent(len(s.icons) - 1)
+	s.Next()
+	assert.Equal(t, 0, s.currentIndex())
+}
+
+func TestSwitcher_Previous(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcher(wins, &testAppProvider{})
+
+	current := s.currentIndex()
+	s.Previous()
+	assert.Equal(t, current-1, s.currentIndex())
+
+	s.setCurrent(0)
+	s.Previous()
+	assert.Equal(t, len(s.icons)-1, s.currentIndex())
+}
+
+func TestSwitcher_HideApply(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcher(wins, &testAppProvider{})
+
+	s.HideApply()
+	assert.True(t, wins[s.currentIndex()].(*dummyWindow).raised)
+}
+
+func TestSwitcher_HideCancel(t *testing.T) {
+	wins := testWindows()
+	s := ShowAppSwitcher(wins, &testAppProvider{})
+
+	s.HideCancel()
+	assert.False(t, wins[s.currentIndex()].(*dummyWindow).raised)
+}

--- a/vendor/fyne.io/fyne/.travis.yml
+++ b/vendor/fyne.io/fyne/.travis.yml
@@ -17,6 +17,7 @@ install: true
 
 before_script:
   - NO_VENDOR=$(find . -iname '*.go' -type f | grep -v /vendor/ | grep -v /cmd/fyne/internal/mobile)
+  - GO111MODULE=off go get golang.org/x/tools/cmd/goimports
   - GO111MODULE=off go get golang.org/x/lint/golint
   - GO111MODULE=off go get github.com/mattn/goveralls
 
@@ -29,7 +30,7 @@ script:
       # check that go mod tidy does not change go.mod/go.sum
       go mod tidy && git diff-index --quiet HEAD -- || ( echo "go.mod/go.sum not up-to-date"; git diff-index HEAD --; false )
     fi
-  - test -z "$(gofmt -s -e -d $NO_VENDOR | tee /dev/stderr)"
+  - test -z "$(goimports -e -d $NO_VENDOR | tee /dev/stderr)"
   - go test -tags ci ./...
   - go vet -tags ci -unsafeptr=false ./...
   - golint -set_exit_status $(go list -tags ci ./... | grep -v /cmd/fyne/internal/mobile)

--- a/vendor/fyne.io/fyne/CHANGELOG.md
+++ b/vendor/fyne.io/fyne/CHANGELOG.md
@@ -7,14 +7,44 @@ More detailed release notes can be found on the [releases page](https://github.c
 
 ### Added
  
-
+* Desktop apps can now create splash windows
+* Support changing the text on form submit/cancel buttons
 
 ### Changed
 
 * Upgraded underlying GLFW library to fix various issues (#183, #61)
 
+### Fixed
+
+*
+
+
+## 1.2.2 - 29 January 2020
+
+### Added
+
+* Add SelectedText() function to Entry widget
+* New mobile.Device interface exposing ShowVirtualKeyboard() (and Hide...)
+
+### Changed
+
+* Scale calculations are now relative to system scale - the default "1" matches the system
+* Update scale on Linux to be "auto" by default (and numbers are relative to 96DPI standard) (#595)
+* When auto scaling check the monitor in the middle of the window, not top left
+* bundled files now have a standard header to optimise some tools like go report card
+* Shortcuts are now handled by the event queue - fixed possible deadlock
 
 ### Fixed
+
+* Scroll horizontally when holding shift key (#579)
+* Updating text and calling refresh for widget doesn't work (#607)
+* Corrected visual behaviour of extended widgets including Entry, Select, Check, Radio and Icon (#615)
+* Entries and Selects that are extended would crash on right click.
+* PasswordEntry created from Entry with Password = true has no revealer
+* Dialog width not always sufficient for title
+* Pasting unicode characters could panic (#597)
+* Setting theme before application start panics on macOS (#626)
+* MenuItem type conflicts with other projects (#632)
 
 
 ## 1.2.1 - 24 December 2019

--- a/vendor/fyne.io/fyne/README-mobile.md
+++ b/vendor/fyne.io/fyne/README-mobile.md
@@ -10,12 +10,13 @@ go get -u fyne.io/fyne fyne.io/fyne/cmd/fyne
 
 ## Android
 
-Get and install the Andoid Native Development Kit (**NDK**). This is platform dependent and may be packaged 
-with various tools that you might already have installed (like Android Studio)
-Once installed set up the appropriate path, the directory you reference should contain `ndk-build`,
-`platforms` and `toolchains`.
+Get and install both the Android Software Development Kit (**SDK**) the Andoid Native Development Kit (**NDK**). This is platform dependent and may be packaged with various tools that you might already have installed (like Android Studio). The recommended approch is to simply install [Android Studio](https://developer.android.com/studio/index.html) and then install the the **NDK** by going to **Tools > SDK Manager** and from **SDK Tools** install the `NDK (Side by side)` package.
 
-`export ANDROID_NDK_HOME=/<path to>/android-ndk`
+Once installed, the appropriate path to the **NDK** need to be set up. The directory you reference should contain `ndk-build`, `platforms` and `toolchains`. The default on Linux is `$HOME/Android/Sdk/ndk/version_of_your_installed_ndk`.
+
+```bash
+export ANDROID_NDK_HOME=/<path to>/android-ndk
+```
 
 ## iOS
 

--- a/vendor/fyne.io/fyne/README.md
+++ b/vendor/fyne.io/fyne/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://godoc.org/fyne.io/fyne" title="GoDoc Reference" rel="nofollow"><img src="https://img.shields.io/badge/go-documentation-blue.svg?style=flat" alt="GoDoc Reference"></a>
-  <a href="https://github.com/fyne-io/fyne/releases/tag/v1.2.0" title="1.2.0 Release" rel="nofollow"><img src="https://img.shields.io/badge/version-1.2.0-blue.svg?style=flat" alt="1.2.0 release"></a>
+  <a href="https://github.com/fyne-io/fyne/releases/tag/v1.2.2" title="1.2.2 Release" rel="nofollow"><img src="https://img.shields.io/badge/version-1.2.2-blue.svg?style=flat" alt="1.2.2 release"></a>
   <a href='http://gophers.slack.com/messages/fyne'><img src='https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=blue' alt='Join us on Slack' /></a>
   <a href='https://fossfi.sh/support-fyneio'><img src='https://img.shields.io/badge/$-support_us-orange.svg?labelWidth=20&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAkCAYAAADPRbkKAAAABmJLR0QA7wAyAD/CTveyAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAB3RJTUUH4wMVCQ4LeuPReAAABDFJREFUWMPVmX9oVWUYxz/3tr5jbX9oYiZWSmNgoYYlUVqraYvIamlCg8pqUBTZr38qMhZZ0A8oIqKIiLJoJtEIsR+zki1mGqQwZTYkImtlgk5Wy7jPnbv90XPgcD3n3Lvdy731wOGc+77nec73Oe/zfp/nOTeVy+WolphZC3CVH9N9OAsMAzuBLkkHkmykKu2AmQGsAjYAC4pQ+QJ4WNJg1R0ws3pgI3DTJFVPAM8AGyRNVMUBB98DLCvBzLtAh6QTwUC6gmGzuUTwAGuBR8MD6QpFzwPAypi5v4HXgRXAEg+vLQm2njSzCyoWQmbWAPwAzIqY/gm4UdJAhN5qoAuojdCbAD4BVlViBdbGgJ8A2gPwZtZsZvea2XwASd1AZ4zNNHA90FgJB9ri6FHStw7+WaAPeA3YbWaBzovAiF/nfMUC+QD4sRIOLIkZ73Hws4BHQuOneY7A2aY/CHdgL3AtsBhYD9TVVMCB0+O2h59nRJBJfej6WOj6Bj8C2VcpFoqSC/38PbArb24zQDabBWhOsFFbNAuZ2UygxZcvcHwPsEPScILecaAuYmoUaJR01MymAU8AFzm7vCxp3MxagW0xpv8EzinogLPC40A7cGpMKHQB6yX9FqE/ACyKMb8VWC0pG6E3D+gF5sbo9km6Ml0A/N3Ad8BtMeABBNwB9JrZ7Ij5PQmPuA7YZWZXmFnan1ljZrf65p2boDuQmInNrAN4I29DJUmT02C+bCtiL/QCo2Y2BIwB7wFzCuj1xGZiM7vcb9gOTAMunUTZMVPSkZCtJuBAmQngIHCupImaCPApoBVokvSrj7UDm4o0Pg84Evo97EkoVUYHXgjK6pNWwB1I5dfdZtbtjUghWSppZ0ivDvirjA4MAosCfCeFhaRcPvhQLV6QbYGhvLHZZQRvwO1hfJNJZFu9qkySNyUdyxu7pkzgc8BDknZPuSMzs8XA58AZEdPbgTZJY3ld2GABOixWXpH0YMk9sZlN96zZ6hn2F+AdYFM4IZlZLfBRQiMzGXlaUmdFmnpPSC3A814alCJjwDpJG+NuqCkC0HzgLi+L651RvgTeAu4ELnHazAJnedkwpwzvoh+4RdLPid+FMpnMDElHY8CvAd4GGiKmR4A1DvwpYHkZabLTO7KCkgYeiwG/3Iu0hoQ6fwvwh6QVwFKn2tEpgB4BPgSaJS0oFnywAnuB5yR15bHNV6HPfUnyqaSVIV0BlwEXe51zNtAYehGHgMNOyfu9F+iXND6V5UplMplXgfuAj4HPgIXAPcXsj5CcKelwNbqiVCaTOd/jrhRZJumbajiQlrQf6OZ/KkEpsQ74vQQ7w1V1QNIh4Gbg+BRs9BXi6kqsAJK+Bq52hihWxoH7/wshFDixw786vF9kmm+TtK+aDsTWQma2EOjg379/zgNO8akh73NfknSw2pv4H3Ayg0FmbTMRAAAAAElFTkSuQmCC' alt='Support Fyne.io' /></a>
   <br />
@@ -23,12 +23,9 @@ widgets such as tables and lists.
 
 # Prerequisites
 
-You will need Go version 1.12 or later.
-As Fyne uses CGo you will require a C compiler (typically gcc).
-If you don't have one set up the instructions at [Compiling](https://github.com/fyne-io/fyne/wiki/Compiling) may help.
-
-By default Fyne uses the [gl golang bindings](https://github.com/go-gl/gl) which means you need a working OpenGL configuration (or GLES for ARM or mobile devices).
-Debian/Ubuntu based systems may also need to install the `libegl1-mesa-dev` and `xorg-dev` packages.
+To develop apps using Fyne you will need Go version 1.12 or later, a C compiler and your system's development tools.
+If you're not sure if that's all installed or you don't know how then check out our
+[Getting Started](https://fyne.io/develop/) document.
 
 Using the standard go tools you can install Fyne's core library using:
 

--- a/vendor/fyne.io/fyne/app/app_mobile_and.go
+++ b/vendor/fyne.io/fyne/app/app_mobile_and.go
@@ -5,11 +5,12 @@
 package app
 
 import (
-	"fyne.io/fyne"
-	"fyne.io/fyne/theme"
 	"net/url"
 	"os"
 	"path/filepath"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/theme"
 )
 
 func defaultTheme() fyne.Theme {

--- a/vendor/fyne.io/fyne/canvas.go
+++ b/vendor/fyne.io/fyne/canvas.go
@@ -19,7 +19,7 @@ type Canvas interface {
 	Scale() float32
 	// SetScale sets ths scale for this canvas only, overriding system and user settings.
 	//
-	// Deprecated: SetScale will be replaced by system wide settings in the future
+	// Deprecated: Settings are now calculated solely on the user configuration and system setup.
 	SetScale(float32)
 
 	Overlay() CanvasObject

--- a/vendor/fyne.io/fyne/canvasobject.go
+++ b/vendor/fyne.io/fyne/canvasobject.go
@@ -71,5 +71,5 @@ type Focusable interface {
 
 // Shortcutable describes any CanvasObject that can respond to shortcut commands (quit, cut, copy, and paste).
 type Shortcutable interface {
-	TypedShortcut(shortcut Shortcut) bool
+	TypedShortcut(Shortcut)
 }

--- a/vendor/fyne.io/fyne/device.go
+++ b/vendor/fyne.io/fyne/device.go
@@ -29,6 +29,7 @@ type Device interface {
 	Orientation() DeviceOrientation
 	IsMobile() bool
 	HasKeyboard() bool
+	SystemScale() float32
 }
 
 // CurrentDevice returns the device information for the current hardware (via the driver)

--- a/vendor/fyne.io/fyne/driver/desktop/driver.go
+++ b/vendor/fyne.io/fyne/driver/desktop/driver.go
@@ -1,0 +1,9 @@
+package desktop
+
+import "fyne.io/fyne"
+
+// Driver represents the extended capabilities of a desktop driver
+type Driver interface {
+	// Create a new borderless window that is centered on screen
+	CreateSplashWindow() fyne.Window
+}

--- a/vendor/fyne.io/fyne/driver/mobile/device.go
+++ b/vendor/fyne.io/fyne/driver/mobile/device.go
@@ -1,0 +1,7 @@
+package mobile
+
+// Device describes functionality only available on mobile
+type Device interface {
+	ShowVirtualKeyboard() // Request that the mobile device show the touch screen keyboard (standard layout)
+	HideVirtualKeyboard() // Request that the mobile device dismiss the touch screen keyboard
+}

--- a/vendor/fyne.io/fyne/internal/driver/glfw/canvas.go
+++ b/vendor/fyne.io/fyne/internal/driver/glfw/canvas.go
@@ -180,22 +180,16 @@ func (c *glCanvas) Scale() float32 {
 
 // SetScale sets the render scale for this specific canvas
 //
-// Deprecated: SetScale will be replaced by system wide settings in the future
-func (c *glCanvas) SetScale(scale float32) {
-	c.setScaleValue(scale)
+// Deprecated: Settings are now calculated solely on the user configuration and system setup.
+func (c *glCanvas) SetScale(_ float32) {
+	if !c.context.(*window).visible {
+		return
+	}
+
+	c.scale = c.context.(*window).calculatedScale()
+	c.setDirty(true)
 
 	c.context.RescaleContext()
-}
-
-func (c *glCanvas) setScaleValue(scale float32) {
-	if scale == fyne.SettingsScaleAuto {
-		c.scale = c.detectedScale
-	} else if scale == 0 {
-		return
-	} else {
-		c.scale = scale
-	}
-	c.setDirty(true)
 }
 
 func (c *glCanvas) OnTypedRune() func(rune) {

--- a/vendor/fyne.io/fyne/internal/driver/glfw/device.go
+++ b/vendor/fyne.io/fyne/internal/driver/glfw/device.go
@@ -1,6 +1,10 @@
 package glfw
 
-import "fyne.io/fyne"
+import (
+	"runtime"
+
+	"fyne.io/fyne"
+)
 
 type glDevice struct {
 }
@@ -18,4 +22,12 @@ func (*glDevice) IsMobile() bool {
 
 func (*glDevice) HasKeyboard() bool {
 	return true // TODO actually check - we could be in tablet mode
+}
+
+func (*glDevice) SystemScale() float32 {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return 1.0
+	}
+
+	return fyne.SettingsScaleAuto
 }

--- a/vendor/fyne.io/fyne/internal/driver/glfw/driver.go
+++ b/vendor/fyne.io/fyne/internal/driver/glfw/driver.go
@@ -1,4 +1,4 @@
-// Package glfw provides a full Fyne desktop driver that uses tje system OpenGL libraries.
+// Package glfw provides a full Fyne desktop driver that uses the system OpenGL libraries.
 // This supports Windows, Mac OS X and Linux using the gl and glfw packages from go-gl.
 package glfw
 

--- a/vendor/fyne.io/fyne/internal/driver/glfw/menu_darwin.m
+++ b/vendor/fyne.io/fyne/internal/driver/glfw/menu_darwin.m
@@ -5,12 +5,12 @@
 
 extern void menu_callback(int);
 
-@interface MenuItem : NSObject {
+@interface FyneMenuItem : NSObject {
 
 }
 @end
 
-@implementation MenuItem
+@implementation FyneMenuItem
 - (void) tapped:(id) sender {
     menu_callback([sender tag]);
 }
@@ -30,7 +30,7 @@ void createDarwinMenu(const char* label) {
 }
 
 void addDarwinMenuItem(const char* label, int id) {
-    MenuItem* tapper = [[MenuItem alloc] init]; // we cannot release this or the menu does not function...
+    FyneMenuItem* tapper = [[FyneMenuItem alloc] init]; // we cannot release this or the menu does not function...
 
     NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:[NSString stringWithUTF8String:label]
         action:@selector(tapped:) keyEquivalent:@""];

--- a/vendor/fyne.io/fyne/internal/driver/glfw/window.go
+++ b/vendor/fyne.io/fyne/internal/driver/glfw/window.go
@@ -258,13 +258,16 @@ func (w *window) SetOnClosed(closed func()) {
 }
 
 func (w *window) getMonitorForWindow() *glfw.Monitor {
+	xOff := w.xpos + (w.width / 2)
+	yOff := w.ypos + (w.height / 2)
+
 	for _, monitor := range glfw.GetMonitors() {
 		x, y := monitor.GetPos()
 
-		if x > w.xpos || y > w.ypos {
+		if x > xOff || y > yOff {
 			continue
 		}
-		if x+monitor.GetVideoMode().Width <= w.xpos || y+monitor.GetVideoMode().Height <= w.ypos {
+		if x+monitor.GetVideoMode().Width <= xOff || y+monitor.GetVideoMode().Height <= yOff {
 			continue
 		}
 
@@ -280,7 +283,7 @@ func (w *window) getMonitorForWindow() *glfw.Monitor {
 	return monitor
 }
 
-func (w *window) selectScale() float32 {
+func (w *window) userScale() float32 {
 	env := os.Getenv("FYNE_SCALE")
 
 	if env != "" && env != "auto" {
@@ -293,20 +296,30 @@ func (w *window) selectScale() float32 {
 
 	if env != "auto" {
 		setting := fyne.CurrentApp().Settings().Scale()
-		switch setting {
-		case fyne.SettingsScaleAuto:
-			// fall through
-		case 0.0:
-			if env == "" {
-				return 1.0
-			}
-			// fall through
-		default:
+		if setting != fyne.SettingsScaleAuto && setting != 0.0 {
 			return setting
 		}
 	}
 
-	return w.detectScale()
+	return 1.0 // user preference for auto is now passed as 1 so the system auto is picked up
+}
+
+func calculateScale(user, system, detected float32) float32 {
+	if user == fyne.SettingsScaleAuto {
+		user = 1.0
+	}
+
+	if system == fyne.SettingsScaleAuto {
+		system = detected
+	}
+
+	return system * user
+}
+func (w *window) calculatedScale() float32 {
+	val := calculateScale(w.userScale(), fyne.CurrentDevice().SystemScale(), w.detectScale())
+	val = float32(math.Round(float64(val*10.0))) / 10.0
+
+	return val
 }
 
 func (w *window) detectScale() float32 {
@@ -318,7 +331,8 @@ func (w *window) detectScale() float32 {
 	if dpi > 1000 || dpi < 10 {
 		dpi = 96
 	}
-	return float32(math.Round(float64(dpi)/144.0*10.0)) / 10.0
+
+	return float32(float64(dpi) / 96.0)
 }
 
 func (w *window) Show() {
@@ -429,21 +443,15 @@ func (w *window) destroy(d *gLDriver) {
 }
 
 func (w *window) moved(viewport *glfw.Window, x, y int) {
-	if w.canvas.scale != w.canvas.detectedScale {
-		return
-	}
-
 	// save coordinates
 	w.xpos, w.ypos = x, y
-	scale := w.canvas.scale
-	newScale := w.detectScale()
-	if scale == newScale {
-		forceWindowRefresh(w)
+
+	if w.canvas.detectedScale == w.detectScale() {
 		return
 	}
 
-	w.canvas.detectedScale = newScale
-	w.canvas.setScaleValue(newScale)
+	w.canvas.detectedScale = w.detectScale()
+	go w.canvas.SetScale(fyne.SettingsScaleAuto) // scale is ignored
 	w.rescaleOnMain()
 }
 
@@ -678,6 +686,11 @@ func (w *window) mouseScrolled(viewport *glfw.Window, xoff float64, yoff float64
 	})
 	switch wid := co.(type) {
 	case fyne.Scrollable:
+		if runtime.GOOS != "darwin" && xoff == 0 &&
+			(viewport.GetKey(glfw.KeyLeftShift) == glfw.Press ||
+				viewport.GetKey(glfw.KeyRightShift) == glfw.Press) {
+			xoff, yoff = yoff, xoff
+		}
 		ev := &fyne.ScrollEvent{}
 		ev.DeltaX = int(xoff * scrollSpeed)
 		ev.DeltaY = int(yoff * scrollSpeed)
@@ -961,7 +974,7 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 			shortcut = &fyne.ShortcutSelectAll{}
 		}
 	}
-	if shortcut == nil && keyDesktopModifier != 0 {
+	if shortcut == nil && keyDesktopModifier != 0 && keyDesktopModifier != desktop.ShiftModifier {
 		shortcut = &desktop.CustomShortcut{
 			KeyName:  keyName,
 			Modifier: keyDesktopModifier,
@@ -969,13 +982,13 @@ func (w *window) keyPressed(viewport *glfw.Window, key glfw.Key, scancode int, a
 	}
 
 	if shortcut != nil {
-		if shortcutable, ok := w.canvas.Focused().(fyne.Shortcutable); ok {
-			if shortcutable.TypedShortcut(shortcut) {
-				return
-			}
-		} else if w.canvas.shortcut.TypedShortcut(shortcut) {
+		if focused, ok := w.canvas.Focused().(fyne.Shortcutable); ok {
+			w.queueEvent(func() { focused.TypedShortcut(shortcut) })
 			return
 		}
+
+		w.queueEvent(func() { w.canvas.shortcut.TypedShortcut(shortcut) })
+		return
 	}
 
 	// No shortcut detected, pass down to TypedKey
@@ -1049,6 +1062,15 @@ func (w *window) RescaleContext() {
 
 func (w *window) rescaleOnMain() {
 	w.fitContent()
+	if w.fullScreen {
+		w.width, w.height = w.viewport.GetSize()
+		scaledFull := fyne.NewSize(
+			internal.UnscaleInt(w.canvas, w.width),
+			internal.UnscaleInt(w.canvas, w.height))
+		w.canvas.Resize(scaledFull)
+		return
+	}
+
 	size := w.canvas.size.Union(w.canvas.MinSize())
 	newWidth, newHeight := w.screenSize(size)
 	w.viewport.SetSize(newWidth, newHeight)
@@ -1081,12 +1103,21 @@ func (w *window) waitForEvents() {
 }
 
 func (d *gLDriver) CreateWindow(title string) fyne.Window {
+	return d.createWindow(title, true)
+}
+
+func (d *gLDriver) createWindow(title string, decorate bool) fyne.Window {
 	var ret *window
 	runOnMain(func() {
 		initOnce.Do(d.initGLFW)
 
 		// make the window hidden, we will set it up and then show it later
 		glfw.WindowHint(glfw.Visible, 0)
+		if decorate {
+			glfw.WindowHint(glfw.Decorated, 1)
+		} else {
+			glfw.WindowHint(glfw.Decorated, 0)
+		}
 		initWindowHints()
 
 		win, err := glfw.CreateWindow(10, 10, title, nil, nil)
@@ -1107,7 +1138,7 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 		ret.canvas.painter.Init()
 		ret.canvas.context = ret
 		ret.canvas.detectedScale = ret.detectScale()
-		ret.canvas.scale = ret.selectScale()
+		ret.canvas.scale = ret.calculatedScale()
 		ret.SetIcon(ret.icon)
 		d.windows = append(d.windows, ret)
 
@@ -1125,6 +1156,13 @@ func (d *gLDriver) CreateWindow(title string) fyne.Window {
 		glfw.DetachCurrentContext()
 	})
 	return ret
+}
+
+func (d *gLDriver) CreateSplashWindow() fyne.Window {
+	win := d.createWindow("", false)
+	win.SetPadded(false)
+	win.CenterOnScreen()
+	return win
 }
 
 func (d *gLDriver) AllWindows() []fyne.Window {

--- a/vendor/fyne.io/fyne/internal/driver/gomobile/canvas.go
+++ b/vendor/fyne.io/fyne/internal/driver/gomobile/canvas.go
@@ -127,14 +127,9 @@ func (c *mobileCanvas) Scale() float32 {
 	return c.scale
 }
 
-func (c *mobileCanvas) SetScale(scale float32) {
-	if scale == fyne.SettingsScaleAuto {
-		c.scale = deviceScale()
-	} else if scale == 0 { // not set in the config
-		return
-	} else {
-		c.scale = scale
-	}
+// Deprecated: Settings are now calculated solely on the user configuration and system setup.
+func (c *mobileCanvas) SetScale(_ float32) {
+	c.scale = fyne.CurrentDevice().SystemScale()
 }
 
 func (c *mobileCanvas) Overlay() fyne.CanvasObject {
@@ -352,7 +347,7 @@ func (c *mobileCanvas) setupThemeListener() {
 // NewCanvas creates a new gomobile mobileCanvas. This is a mobileCanvas that will render on a mobile device using OpenGL.
 func NewCanvas() fyne.Canvas {
 	ret := &mobileCanvas{padded: true}
-	ret.scale = deviceScale()
+	ret.scale = fyne.CurrentDevice().SystemScale()
 	ret.refreshQueue = make(chan fyne.CanvasObject, 1024)
 	ret.touched = make(map[int]mobile.Touchable)
 	ret.lastTapDownPos = make(map[int]fyne.Position)

--- a/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_android.go
+++ b/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_android.go
@@ -8,6 +8,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	return fyne.NewSize(0, 48), fyne.NewSize(0, 0)
 }
 
-func deviceScale() float32 {
+func (*device) SystemScale() float32 {
 	return 3 // TODO detect device DPI and pick from 1, 1.5, 2, 3 and 4
 }

--- a/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_desktop.go
+++ b/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_desktop.go
@@ -3,9 +3,6 @@
 package gomobile
 
 import (
-	"os"
-	"strconv"
-
 	"fyne.io/fyne"
 )
 
@@ -13,15 +10,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	return fyne.NewSize(0, 0), fyne.NewSize(0, 0)
 }
 
-func deviceScale() float32 {
-	env := os.Getenv("FYNE_SCALE")
-	if env != "" && env != "auto" {
-		scale, err := strconv.ParseFloat(env, 32)
-		if err == nil && scale != 0 {
-			return float32(scale)
-		}
-		fyne.LogError("Error reading scale", err)
-	}
-
-	return 1
+func (*device) SystemScale() float32 {
+	return 2
 }

--- a/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_ios.go
+++ b/vendor/fyne.io/fyne/internal/driver/gomobile/canvas_ios.go
@@ -14,6 +14,6 @@ func devicePadding() (topLeft, bottomRight fyne.Size) {
 	}
 }
 
-func deviceScale() float32 {
+func (*device) SystemScale() float32 {
 	return 3 // TODO return 2 for < iPhone X, Xs but 3 for Plus/Max size
 }

--- a/vendor/fyne.io/fyne/internal/driver/gomobile/device.go
+++ b/vendor/fyne.io/fyne/internal/driver/gomobile/device.go
@@ -14,7 +14,7 @@ var currentOrientation size.Orientation
 // Declare conformity with Device
 var _ fyne.Device = (*device)(nil)
 
-func (device) Orientation() fyne.DeviceOrientation {
+func (*device) Orientation() fyne.DeviceOrientation {
 	switch currentOrientation {
 	case size.OrientationLandscape:
 		return fyne.OrientationHorizontalLeft
@@ -23,10 +23,18 @@ func (device) Orientation() fyne.DeviceOrientation {
 	}
 }
 
-func (device) IsMobile() bool {
+func (*device) IsMobile() bool {
 	return true
 }
 
-func (device) HasKeyboard() bool {
+func (*device) HasKeyboard() bool {
 	return false
+}
+
+func (*device) ShowVirtualKeyboard() {
+	showVirtualKeyboard()
+}
+
+func (*device) HideVirtualKeyboard() {
+	hideVirtualKeyboard()
 }

--- a/vendor/fyne.io/fyne/layout/gridlayout.go
+++ b/vendor/fyne.io/fyne/layout/gridlayout.go
@@ -123,7 +123,7 @@ func (g *gridLayout) MinSize(objects []fyne.CanvasObject) fyne.Size {
 	return minContentSize.Add(fyne.NewSize(theme.Padding()*(rows-1), theme.Padding()*(g.Cols-1)))
 }
 
-// NewGridLayout returns a grid layout arranged in a specified number of coulmns.
+// NewGridLayout returns a grid layout arranged in a specified number of columns.
 // The number of rows will depend on how many children are in the container that uses this layout.
 func NewGridLayout(cols int) fyne.Layout {
 	return NewGridLayoutWithColumns(cols)

--- a/vendor/fyne.io/fyne/shortcut.go
+++ b/vendor/fyne.io/fyne/shortcut.go
@@ -12,15 +12,12 @@ type ShortcutHandler struct {
 }
 
 // TypedShortcut handle the registered shortcut
-func (sh *ShortcutHandler) TypedShortcut(shortcut Shortcut) bool {
-	if shortcut == nil {
-		return false
+func (sh *ShortcutHandler) TypedShortcut(shortcut Shortcut) {
+	if _, ok := sh.entry[shortcut.ShortcutName()]; !ok {
+		return
 	}
-	if sc, ok := sh.entry[shortcut.ShortcutName()]; ok {
-		sc(shortcut)
-		return true
-	}
-	return false
+
+	sh.entry[shortcut.ShortcutName()](shortcut)
 }
 
 // AddShortcut register an handler to be executed when the shortcut action is triggered

--- a/vendor/fyne.io/fyne/test/device.go
+++ b/vendor/fyne.io/fyne/test/device.go
@@ -19,3 +19,7 @@ func (d *device) IsMobile() bool {
 func (d *device) HasKeyboard() bool {
 	return false
 }
+
+func (d *device) SystemScale() float32 {
+	return 1
+}

--- a/vendor/fyne.io/fyne/test/util.go
+++ b/vendor/fyne.io/fyne/test/util.go
@@ -1,6 +1,9 @@
 package test
 
-import "fyne.io/fyne"
+import (
+	"fyne.io/fyne"
+	"fyne.io/fyne/internal/cache"
+)
 
 // Tap simulates a left mouse click on the specified object.
 func Tap(obj fyne.Tappable) {
@@ -55,4 +58,10 @@ func Type(obj fyne.Focusable, chars string) {
 // rather than a focusable widget.
 func TypeOnCanvas(c fyne.Canvas, chars string) {
 	typeChars([]rune(chars), c.OnTypedRune())
+}
+
+// WidgetRenderer allows test scripts to gain access to the current renderer for a widget.
+// This can be used for verifying correctness of rendered components for a widget in unit tests.
+func WidgetRenderer(wid fyne.Widget) fyne.WidgetRenderer {
+	return cache.Renderer(wid)
 }

--- a/vendor/fyne.io/fyne/theme/bundled-icons.go
+++ b/vendor/fyne.io/fyne/theme/bundled-icons.go
@@ -1,3 +1,4 @@
+// auto-generated
 // **** THIS FILE IS AUTO-GENERATED, PLEASE DO NOT EDIT IT **** //
 
 package theme

--- a/vendor/fyne.io/fyne/widget/button.go
+++ b/vendor/fyne.io/fyne/widget/button.go
@@ -130,7 +130,7 @@ func (b *buttonRenderer) Refresh() {
 	}
 
 	b.Layout(b.button.Size())
-	canvas.Refresh(b.button)
+	canvas.Refresh(b.button.super())
 }
 
 func (b *buttonRenderer) Objects() []fyne.CanvasObject {
@@ -177,13 +177,13 @@ func (b *Button) TappedSecondary(*fyne.PointEvent) {
 // MouseIn is called when a desktop pointer enters the widget
 func (b *Button) MouseIn(*desktop.MouseEvent) {
 	b.hovered = true
-	Refresh(b)
+	b.Refresh()
 }
 
 // MouseOut is called when a desktop pointer exits the widget
 func (b *Button) MouseOut() {
 	b.hovered = false
-	Refresh(b)
+	b.Refresh()
 }
 
 // MouseMoved is called when a desktop pointer hovers over the widget
@@ -226,7 +226,7 @@ func (b *Button) CreateRenderer() fyne.WidgetRenderer {
 func (b *Button) SetText(text string) {
 	b.Text = text
 
-	Refresh(b)
+	b.Refresh()
 }
 
 // SetIcon updates the icon on a label - pass nil to hide an icon
@@ -239,7 +239,7 @@ func (b *Button) SetIcon(icon fyne.Resource) {
 		b.disabledIcon = nil
 	}
 
-	Refresh(b)
+	b.Refresh()
 }
 
 // NewButton creates a new button widget with the set label and tap handler

--- a/vendor/fyne.io/fyne/widget/check.go
+++ b/vendor/fyne.io/fyne/widget/check.go
@@ -82,7 +82,7 @@ func (c *checkRenderer) Refresh() {
 		c.focusIndicator.FillColor = theme.BackgroundColor()
 	}
 
-	canvas.Refresh(c.check)
+	canvas.Refresh(c.check.super())
 }
 
 func (c *checkRenderer) Objects() []fyne.CanvasObject {
@@ -116,7 +116,7 @@ func (c *Check) SetChecked(checked bool) {
 		c.OnChanged(c.Checked)
 	}
 
-	Refresh(c)
+	c.Refresh()
 }
 
 // Hide this widget, if it was previously visible
@@ -135,13 +135,13 @@ func (c *Check) MouseIn(*desktop.MouseEvent) {
 		return
 	}
 	c.hovered = true
-	Refresh(c)
+	c.Refresh()
 }
 
 // MouseOut is called when a desktop pointer exits the widget
 func (c *Check) MouseOut() {
 	c.hovered = false
-	Refresh(c)
+	c.Refresh()
 }
 
 // MouseMoved is called when a desktop pointer hovers over the widget
@@ -202,14 +202,14 @@ func (c *Check) FocusGained() {
 	}
 	c.focused = true
 
-	Refresh(c)
+	c.Refresh()
 }
 
 // FocusLost is called when the Check has had focus removed.
 func (c *Check) FocusLost() {
 	c.focused = false
 
-	Refresh(c)
+	c.Refresh()
 }
 
 // Focused returns whether or not this Check has focus.

--- a/vendor/fyne.io/fyne/widget/entry.go
+++ b/vendor/fyne.io/fyne/widget/entry.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/theme"
 )
 
@@ -50,7 +51,7 @@ func (e *entryRenderer) MinSize() fyne.Size {
 // This process could be optimized in the scenario where the user is selecting upwards:
 // If the upwards case instead produces an order-reversed slice then only the newest rectangle would
 // require movement and resizing. The existing solution creates a new rectangle and then moves/resizes
-// all rectangles to comply with the occurance order as stated above.
+// all rectangles to comply with the occurrence order as stated above.
 func (e *entryRenderer) buildSelection() {
 	e.entry.RLock()
 	cursorRow, cursorCol := e.entry.CursorRow, e.entry.CursorColumn
@@ -164,8 +165,6 @@ func (e *entryRenderer) Layout(size fyne.Size) {
 
 	e.entry.placeholder.Resize(entrySize)
 	e.entry.placeholder.Move(fyne.NewPos(theme.Padding(), theme.Padding()))
-
-	e.moveCursor()
 }
 
 func (e *entryRenderer) BackgroundColor() color.Color {
@@ -173,6 +172,9 @@ func (e *entryRenderer) BackgroundColor() color.Color {
 }
 
 func (e *entryRenderer) Refresh() {
+	if e.entry.Text != string(e.entry.textProvider().buffer) {
+		e.entry.textProvider().SetText(e.entry.Text)
+	}
 	if e.entry.textProvider().len() == 0 && e.entry.Visible() {
 		e.entry.placeholderProvider().Show()
 	} else if e.entry.placeholderProvider().Visible() {
@@ -191,6 +193,7 @@ func (e *entryRenderer) Refresh() {
 			e.line.FillColor = theme.ButtonColor()
 		}
 	}
+	e.moveCursor()
 
 	for _, selection := range e.selection {
 		selection.(*canvas.Rectangle).Hidden = !e.entry.focused && !e.entry.disabled
@@ -201,7 +204,7 @@ func (e *entryRenderer) Refresh() {
 	if e.entry.passwordRevealer != nil {
 		e.entry.passwordRevealer.Refresh()
 	}
-	canvas.Refresh(e.entry)
+	canvas.Refresh(e.entry.super())
 }
 
 func (e *entryRenderer) Objects() []fyne.CanvasObject {
@@ -214,9 +217,9 @@ func (e *entryRenderer) Objects() []fyne.CanvasObject {
 
 func (e *entryRenderer) Destroy() {
 	if e.entry.popUp != nil {
-		c := fyne.CurrentApp().Driver().CanvasForObject(e.entry)
+		c := fyne.CurrentApp().Driver().CanvasForObject(e.entry.super())
 		c.SetOverlay(nil)
-		Renderer(e.entry.popUp).Destroy()
+		cache.Renderer(e.entry.popUp).Destroy()
 		e.entry.popUp = nil
 	}
 }
@@ -273,7 +276,7 @@ func (e *Entry) SetText(text string) {
 		e.CursorColumn = 0
 		e.CursorRow = 0
 		e.Unlock()
-		Renderer(e).(*entryRenderer).moveCursor()
+		e.Refresh()
 	} else {
 		provider := e.textProvider()
 		if e.CursorRow >= provider.rows() {
@@ -326,7 +329,7 @@ func (e *Entry) updateText(text string) {
 		e.OnChanged(text)
 	}
 
-	Refresh(e)
+	e.Refresh()
 }
 
 // selection returns the start and end text positions for the selected span of text
@@ -360,9 +363,9 @@ func (e *Entry) selection() (int, int) {
 	return e.textPosFromRowCol(rowA, colA), e.textPosFromRowCol(rowB, colB)
 }
 
-// selectedText returns the text currently selected in this Entry.
+// SelectedText returns the text currently selected in this Entry.
 // If there is no selection it will return the empty string.
-func (e *Entry) selectedText() string {
+func (e *Entry) SelectedText() string {
 	if e.selecting == false {
 		return ""
 	}
@@ -418,14 +421,14 @@ func (e *Entry) FocusGained() {
 	}
 	e.focused = true
 
-	Refresh(e)
+	e.Refresh()
 }
 
 // FocusLost is called when the Entry has had focus removed.
 func (e *Entry) FocusLost() {
 	e.focused = false
 
-	Refresh(e)
+	e.Refresh()
 }
 
 // Focused returns whether or not this Entry has focus.
@@ -467,7 +470,7 @@ func (e *Entry) copyToClipboard(clipboard fyne.Clipboard) {
 		return
 	}
 
-	clipboard.SetContent(e.selectedText())
+	clipboard.SetContent(e.SelectedText())
 }
 
 // pasteFromClipboard inserts text from the clipboard content,
@@ -490,11 +493,16 @@ func (e *Entry) pasteFromClipboard(clipboard fyne.Clipboard) {
 		e.CursorColumn += len(runes)
 	} else {
 		e.CursorRow += newlines
-		lastNewline := strings.LastIndex(text, "\n")
-		e.CursorColumn = len(runes) - lastNewline - 1
+		lastNewlineIndex := 0
+		for i, r := range runes {
+			if r == '\n' {
+				lastNewlineIndex = i
+			}
+		}
+		e.CursorColumn = len(runes) - lastNewlineIndex - 1
 	}
 	e.updateText(provider.String())
-	Renderer(e).(*entryRenderer).moveCursor()
+	e.Refresh()
 }
 
 // selectAll selects all text in entry
@@ -509,7 +517,6 @@ func (e *Entry) selectAll() {
 	e.selecting = true
 	e.Unlock()
 
-	Renderer(e).(*entryRenderer).moveCursor()
 	e.Refresh()
 }
 
@@ -517,8 +524,6 @@ func (e *Entry) selectAll() {
 //
 // Opens the PopUpMenu with `Paste` item to paste text from the clipboard.
 func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
-	c := fyne.CurrentApp().Driver().CanvasForObject(e)
-
 	cutItem := fyne.NewMenuItem("Cut", func() {
 		clipboard := fyne.CurrentApp().Driver().AllWindows()[0].Clipboard()
 		e.cutToClipboard(clipboard)
@@ -533,8 +538,10 @@ func (e *Entry) TappedSecondary(pe *fyne.PointEvent) {
 	})
 	selectAllItem := fyne.NewMenuItem("Select all", e.selectAll)
 
-	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(e)
+	super := e.super()
+	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(super)
 	popUpPos := entryPos.Add(fyne.NewPos(pe.Position.X, pe.Position.Y))
+	c := fyne.CurrentApp().Driver().CanvasForObject(super)
 
 	if e.Disabled() && e.password() {
 		return // no popup options for a disabled password field
@@ -609,7 +616,6 @@ func (e *Entry) updateMousePointer(ev *fyne.PointEvent, rightClick bool) {
 		e.selectColumn = col
 	}
 	e.Unlock()
-	Renderer(e).(*entryRenderer).moveCursor()
 	e.Refresh()
 }
 
@@ -683,7 +689,6 @@ func (e *Entry) DoubleTapped(ev *fyne.PointEvent) {
 	}
 	e.selecting = true
 	e.Unlock()
-	Renderer(e).(*entryRenderer).moveCursor()
 	e.Refresh()
 }
 
@@ -711,7 +716,7 @@ func (e *Entry) TypedRune(r rune) {
 	e.CursorColumn += len(runes)
 	e.Unlock()
 	e.updateText(provider.String())
-	Renderer(e.impl).(*entryRenderer).moveCursor()
+	e.Refresh()
 }
 
 // KeyDown handler for keypress events - used to store shift modifier state for text selection
@@ -828,8 +833,7 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 
 	if e.selectKeyDown || e.selecting {
 		if e.selectingKeyHandler(key) {
-			e.updateText(provider.String())
-			Renderer(e).(*entryRenderer).moveCursor()
+			e.Refresh()
 			return
 		}
 	}
@@ -954,12 +958,12 @@ func (e *Entry) TypedKey(key *fyne.KeyEvent) {
 	}
 
 	e.updateText(provider.String())
-	Renderer(e).(*entryRenderer).moveCursor()
+	e.Refresh()
 }
 
 // TypedShortcut implements the Shortcutable interface
-func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) bool {
-	return e.shortcut.TypedShortcut(shortcut)
+func (e *Entry) TypedShortcut(shortcut fyne.Shortcut) {
+	e.shortcut.TypedShortcut(shortcut)
 }
 
 // textProvider returns the text handler for this entry
@@ -1064,6 +1068,18 @@ func (e *Entry) CreateRenderer() fyne.WidgetRenderer {
 
 	objects := []fyne.CanvasObject{line, e.placeholderProvider(), e.textProvider(), cursor}
 
+	if e.Password && e.passwordRevealer == nil {
+		// An entry widget has been created via struct setting manually
+		// the Password field to true. Going to enable the password revealer.
+		pr := &passwordRevealer{
+			icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),
+			entry: e,
+		}
+		pr.ExtendBaseWidget(pr)
+
+		e.passwordRevealer = pr
+	}
+
 	if e.passwordRevealer != nil {
 		objects = append(objects, e.passwordRevealer)
 	}
@@ -1088,18 +1104,26 @@ func (e *Entry) registerShortcut() {
 	})
 }
 
+// ExtendBaseWidget is used by an extending widget to make use of BaseWidget functionality.
+func (e *Entry) ExtendBaseWidget(wid fyne.Widget) {
+	if e.BaseWidget.impl != nil {
+		return
+	}
+
+	e.BaseWidget.impl = wid
+	e.registerShortcut()
+}
+
 // NewEntry creates a new single line entry widget.
 func NewEntry() *Entry {
 	e := &Entry{}
 	e.ExtendBaseWidget(e)
-	e.registerShortcut()
 	return e
 }
 
 // NewMultiLineEntry creates a new entry that allows multiple lines
 func NewMultiLineEntry() *Entry {
 	e := &Entry{MultiLine: true}
-	e.registerShortcut()
 	e.ExtendBaseWidget(e)
 	return e
 }
@@ -1108,7 +1132,6 @@ func NewMultiLineEntry() *Entry {
 func NewPasswordEntry() *Entry {
 	e := &Entry{Password: true}
 	e.ExtendBaseWidget(e)
-	e.registerShortcut()
 
 	pr := &passwordRevealer{
 		icon:  canvas.NewImageFromResource(theme.VisibilityOffIcon()),

--- a/vendor/fyne.io/fyne/widget/form.go
+++ b/vendor/fyne.io/fyne/widget/form.go
@@ -24,9 +24,11 @@ func NewFormItem(text string, widget fyne.CanvasObject) *FormItem {
 type Form struct {
 	BaseWidget
 
-	Items    []*FormItem
-	OnSubmit func()
-	OnCancel func()
+	Items      []*FormItem
+	OnSubmit   func()
+	OnCancel   func()
+	SubmitText string
+	CancelText string
 
 	itemGrid *fyne.Container
 }
@@ -82,13 +84,20 @@ func (f *Form) CreateRenderer() fyne.WidgetRenderer {
 
 	buttons := NewHBox(layout.NewSpacer())
 	if f.OnCancel != nil {
-		buttons.Append(NewButtonWithIcon("Cancel", theme.CancelIcon(), f.OnCancel))
+		if f.CancelText == "" {
+			f.CancelText = "Cancel"
+		}
+
+		buttons.Append(NewButtonWithIcon(f.CancelText, theme.CancelIcon(), f.OnCancel))
 	}
 	if f.OnSubmit != nil {
-		submit := NewButtonWithIcon("Submit", theme.ConfirmIcon(), f.OnSubmit)
-		submit.Style = PrimaryButton
+		if f.SubmitText == "" {
+			f.SubmitText = "Submit"
+		}
 
-		buttons.Append(submit)
+		submitButton := NewButtonWithIcon(f.SubmitText, theme.ConfirmIcon(), f.OnSubmit)
+		submitButton.Style = PrimaryButton
+		buttons.Append(submitButton)
 	}
 	return Renderer(NewVBox(f.itemGrid, buttons))
 }

--- a/vendor/fyne.io/fyne/widget/icon.go
+++ b/vendor/fyne.io/fyne/widget/icon.go
@@ -46,7 +46,7 @@ func (i *iconRenderer) Refresh() {
 	}
 	i.Layout(i.image.Size())
 
-	canvas.Refresh(i.image)
+	canvas.Refresh(i.image.super())
 }
 
 func (i *iconRenderer) Destroy() {
@@ -62,7 +62,7 @@ type Icon struct {
 // SetResource updates the resource rendered in this icon widget
 func (i *Icon) SetResource(res fyne.Resource) {
 	i.Resource = res
-	i.refresh(i)
+	i.Refresh()
 }
 
 // MinSize returns the size that this widget should not shrink below
@@ -84,6 +84,7 @@ func (i *Icon) CreateRenderer() fyne.WidgetRenderer {
 // NewIcon returns a new icon widget that displays a themed icon resource
 func NewIcon(res fyne.Resource) *Icon {
 	icon := &Icon{}
+	icon.ExtendBaseWidget(icon)
 	icon.SetResource(res) // force the image conversion
 
 	return icon

--- a/vendor/fyne.io/fyne/widget/select.go
+++ b/vendor/fyne.io/fyne/widget/select.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne"
 	"fyne.io/fyne/canvas"
 	"fyne.io/fyne/driver/desktop"
+	"fyne.io/fyne/internal/cache"
 	"fyne.io/fyne/theme"
 )
 
@@ -78,7 +79,7 @@ func (s *selectRenderer) Refresh() {
 	}
 
 	s.Layout(s.combo.Size())
-	canvas.Refresh(s.combo)
+	canvas.Refresh(s.combo.super())
 }
 
 func (s *selectRenderer) Objects() []fyne.CanvasObject {
@@ -89,7 +90,7 @@ func (s *selectRenderer) Destroy() {
 	if s.combo.popUp != nil {
 		c := fyne.CurrentApp().Driver().CanvasForObject(s.combo)
 		c.SetOverlay(nil)
-		Renderer(s.combo.popUp).Destroy()
+		cache.Renderer(s.combo.popUp).Destroy()
 		s.combo.popUp = nil
 	}
 }
@@ -124,7 +125,7 @@ func (s *Select) optionTapped(text string) {
 
 // Tapped is called when a pointer tapped event is captured and triggers any tap handler
 func (s *Select) Tapped(*fyne.PointEvent) {
-	c := fyne.CurrentApp().Driver().CanvasForObject(s)
+	c := fyne.CurrentApp().Driver().CanvasForObject(s.super())
 
 	var items []*fyne.MenuItem
 	for _, option := range s.Options {
@@ -135,7 +136,7 @@ func (s *Select) Tapped(*fyne.PointEvent) {
 		items = append(items, item)
 	}
 
-	buttonPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(s)
+	buttonPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(s.super())
 	popUpPos := buttonPos.Add(fyne.NewPos(0, s.Size().Height))
 
 	s.popUp = NewPopUpMenuAtPosition(fyne.NewMenu("", items...), c, popUpPos)
@@ -149,13 +150,13 @@ func (s *Select) TappedSecondary(*fyne.PointEvent) {
 // MouseIn is called when a desktop pointer enters the widget
 func (s *Select) MouseIn(*desktop.MouseEvent) {
 	s.hovered = true
-	Refresh(s)
+	s.Refresh()
 }
 
 // MouseOut is called when a desktop pointer exits the widget
 func (s *Select) MouseOut() {
 	s.hovered = false
-	Refresh(s)
+	s.Refresh()
 }
 
 // MouseMoved is called when a desktop pointer hovers over the widget
@@ -202,13 +203,10 @@ func (s *Select) SetSelected(text string) {
 		s.OnChanged(text)
 	}
 
-	Refresh(s)
+	s.Refresh()
 }
 
 // NewSelect creates a new select widget with the set list of options and changes handler
 func NewSelect(options []string, changed func(string)) *Select {
-	combo := &Select{BaseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
-
-	Renderer(combo).Layout(combo.MinSize())
-	return combo
+	return &Select{BaseWidget{}, "", options, defaultPlaceHolder, changed, false, nil}
 }

--- a/vendor/fyne.io/fyne/widget/widget.go
+++ b/vendor/fyne.io/fyne/widget/widget.go
@@ -57,10 +57,12 @@ func (w *BaseWidget) Move(pos fyne.Position) {
 
 // MinSize for the widget - it should never be resized below this value.
 func (w *BaseWidget) MinSize() fyne.Size {
-	if w.impl == nil || cache.Renderer(w.impl) == nil {
+	r := cache.Renderer(w.impl)
+	if r == nil {
 		return fyne.NewSize(0, 0)
 	}
-	return cache.Renderer(w.impl).MinSize()
+
+	return r.MinSize()
 }
 
 // CreateRenderer of BaseWidget does nothing, it must be overridden
@@ -114,7 +116,13 @@ func (w *BaseWidget) refresh(wid fyne.Widget) {
 	render.Refresh()
 }
 
+// super will return the actual object that this represents.
+// If extended then this is the extending widget, otherwise it is self.
 func (w *BaseWidget) super() fyne.Widget {
+	if w.impl == nil {
+		return w
+	}
+
 	return w.impl
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# fyne.io/fyne v1.2.2-0.20191224225653-64936716f619
+# fyne.io/fyne v1.2.2-0.20200129164526-631a82cd1cae
 fyne.io/fyne
 fyne.io/fyne/app
 fyne.io/fyne/canvas

--- a/wm/switcher.go
+++ b/wm/switcher.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package wm
 
 import (

--- a/wm/switcher.go
+++ b/wm/switcher.go
@@ -1,0 +1,72 @@
+package wm
+
+import (
+	"fyne.io/desktop"
+	"fyne.io/desktop/internal/ui"
+
+	"github.com/BurntSushi/xgb/xproto"
+)
+
+// switcherInstance and the methods below manage the X to ui.Switcher bindings.
+// This is needed due to the way that releasing Alt is only reported if we grab the whole keyboard.
+// Therefore the UI cannot handle keyboard input - so we add it here instead.
+var switcherInstance *ui.Switcher
+
+func (x *x11WM) showOrSelectAppSwitcher(reverse bool) {
+	xproto.GrabKeyboard(x.x.Conn(), true, x.x.RootWin(), xproto.TimeCurrentTime, xproto.GrabModeAsync, xproto.GrabModeAsync)
+
+	if switcherInstance != nil {
+		if reverse {
+			switcherInstance.Previous()
+		} else {
+			switcherInstance.Next()
+		}
+
+		return
+	}
+
+	go func() {
+		if reverse {
+			switcherInstance = ui.ShowAppSwitcherReverse(x.Windows(), desktop.Instance().IconProvider())
+		} else {
+			switcherInstance = ui.ShowAppSwitcher(x.Windows(), desktop.Instance().IconProvider())
+		}
+	}()
+}
+
+func (x *x11WM) previousAppSwitcher() {
+	if switcherInstance == nil {
+		return
+	}
+
+	go switcherInstance.Previous()
+}
+
+func (x *x11WM) nextAppSwitcher() {
+	if switcherInstance == nil {
+		return
+	}
+
+	go switcherInstance.Next()
+}
+
+func (x *x11WM) cancelAppSwitcher() {
+	if switcherInstance == nil {
+		return
+	}
+
+	go switcherInstance.HideCancel()
+	xproto.UngrabKeyboard(x.x.Conn(), xproto.TimeCurrentTime)
+	switcherInstance = nil
+}
+
+func (x *x11WM) applyAppSwitcher() {
+	if switcherInstance == nil {
+		return
+	}
+
+	go switcherInstance.HideApply()
+	xproto.UngrabKeyboard(x.x.Conn(), xproto.TimeCurrentTime)
+	windowClientListStackingUpdate(x)
+	switcherInstance = nil
+}


### PR DESCRIPTION
Addition of a graphical app switcher using icon and name of app (or window if no app matches).
It is shown with Alt-Tab or Alt-Shift-Tab (for backwards cycle).
Pressing Tab or Shift-Tab cycles the icons, as does Left and Right.
Escape will cancel without changing, releasing Alt or pressing Enter will apply and close.
You can also mouse click to select

UI tests included.
This required an updating of Fyne to get `CreateSplashWindow`.

![FyneDesk-switcher](https://user-images.githubusercontent.com/294436/73381783-3e9e4280-42be-11ea-8275-51ed7608ab4c.png)
