### PR TITLE
This fixes several issues related to colormaps and client map requests

### DIFF
--- a/wm/client.go
+++ b/wm/client.go
@@ -38,7 +38,8 @@ type client struct {
 func newClient(win xproto.Window, wm *x11WM) *client {
 	c := &client{win: win, wm: wm}
 	err := xproto.ChangeWindowAttributesChecked(wm.x.Conn(), win, xproto.CwEventMask,
-		[]uint32{xproto.EventMaskPropertyChange | xproto.EventMaskEnterWindow | xproto.EventMaskLeaveWindow}).Check()
+		[]uint32{xproto.EventMaskPropertyChange | xproto.EventMaskEnterWindow | xproto.EventMaskLeaveWindow |
+			xproto.EventMaskVisibilityChange}).Check()
 	if err != nil {
 		fyne.LogError("Could not change window attributes", err)
 	}

--- a/wm/property.go
+++ b/wm/property.go
@@ -279,10 +279,16 @@ func windowStateSet(x *xgbutil.XUtil, win xproto.Window, state uint) {
 
 func windowTransientForGet(x *xgbutil.XUtil, win xproto.Window) xproto.Window {
 	transient, err := icccm.WmTransientForGet(x, win)
-	if err != nil {
-		return 0
+	if err == nil {
+		return transient
 	}
-	return transient
+	hints, err := icccm.WmHintsGet(x, win)
+	if err == nil {
+		if hints.Flags&icccm.HintWindowGroup > 0 {
+			return hints.WindowGroup
+		}
+	}
+	return 0
 }
 
 func windowTypeGet(x *xgbutil.XUtil, win xproto.Window) []string {

--- a/wm/transient.go
+++ b/wm/transient.go
@@ -1,0 +1,36 @@
+// +build linux
+
+package wm // import "fyne.io/desktop/wm"
+
+import "github.com/BurntSushi/xgb/xproto"
+
+func (x *x11WM) transientChildAdd(leader xproto.Window, child xproto.Window) {
+	for _, win := range x.transientMap[leader] {
+		if win == child {
+			return
+		}
+	}
+	x.transientMap[leader] = append(x.transientMap[leader], child)
+}
+
+func (x *x11WM) transientChildRemove(leader xproto.Window, child xproto.Window) {
+	for i, win := range x.transientMap[leader] {
+		if win == child {
+			x.transientMap[leader] = append(x.transientMap[leader][:i], x.transientMap[leader][i+1:]...)
+		}
+	}
+}
+
+// Window C could be Transient for window B which is transient for WindowA - We sometimes need the very top level
+func (x *x11WM) transientTopLeaderGet(child xproto.Window) xproto.Window {
+	var topLeader xproto.Window
+	for child != 0 {
+		topLeader = child
+		child = windowTransientForGet(x.x, child)
+	}
+	return topLeader
+}
+
+func (x *x11WM) transientLeaderRemove(leader xproto.Window) {
+	delete(x.transientMap, leader)
+}


### PR DESCRIPTION
Initially we had turned SubstructureNotify on for the root window - This is incorrect as we were picking up things like map request events from clients that were not managed by us and shouldn't be managed by us and thus managing those clients incorrectly.

Introduces transient handling and colormap handling.