### PR TITLE
Fix QT App corruption

### DIFF
--- a/internal/ui/desk.go
+++ b/internal/ui/desk.go
@@ -199,9 +199,11 @@ func (l *deskLayout) WindowManager() desktop.WindowManager {
 
 func (l *deskLayout) scaleVars(scale float32) []string {
 	intScale := int(math.Round(float64(scale)))
+	// Qt toolkit cannot handle scale < 1
+	positiveScale := math.Max(1.0, float64(scale))
 
 	return []string{
-		fmt.Sprintf("QT_SCALE_FACTOR=%1.1f", scale),
+		fmt.Sprintf("QT_SCALE_FACTOR=%1.1f", positiveScale),
 		fmt.Sprintf("GDK_SCALE=%d", intScale),
 		fmt.Sprintf("ELM_SCALE=%1.1f", scale),
 	}

--- a/internal/ui/desk_test.go
+++ b/internal/ui/desk_test.go
@@ -218,13 +218,22 @@ func TestDeskLayout_Layout(t *testing.T) {
 	assert.Equal(t, l.bar.Position().Y+l.bar.Size().Height, deskSize.Height)
 }
 
-func TestScaleVars(t *testing.T) {
+func TestScaleVars_Up(t *testing.T) {
 	l := &deskLayout{}
 	l.screens = &testScreensProvider{}
 	env := l.scaleVars(1.8)
 	assert.Contains(t, env, "QT_SCALE_FACTOR=1.8")
 	assert.Contains(t, env, "GDK_SCALE=2")
 	assert.Contains(t, env, "ELM_SCALE=1.8")
+}
+
+func TestScaleVars_Down(t *testing.T) {
+	l := &deskLayout{}
+	l.screens = &testScreensProvider{}
+	env := l.scaleVars(0.9)
+	assert.Contains(t, env, "QT_SCALE_FACTOR=1.0")
+	assert.Contains(t, env, "GDK_SCALE=1")
+	assert.Contains(t, env, "ELM_SCALE=0.9")
 }
 
 func TestBackgroundChange(t *testing.T) {

--- a/wm/desk.go
+++ b/wm/desk.go
@@ -43,7 +43,7 @@ type x11WM struct {
 
 	allowedActions []string
 	supportedHints []string
-	transientMap map[xproto.Window][]xproto.Window
+	transientMap   map[xproto.Window][]xproto.Window
 }
 
 type moveResizeType uint32


### PR DESCRIPTION
Turns out QT_SCALE_FACTOR is not reliable below 1.

This ensures value is neer below 1

https://www.reddit.com/r/kde/comments/a54rul/how_to_set_scaling_to_below_100/
> Qt itself doesn't work with scale factors < 1. Try QT_SCALE_FACTOR=0.75 kcalc.